### PR TITLE
APPDEV-272

### DIFF
--- a/app/src/main/java/nu/yona/app/api/manager/impl/AuthenticateManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/AuthenticateManagerImpl.java
@@ -192,7 +192,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                         authNetwork.doVerifyPin(authenticateDao.getUser().getLinks().getVerifyPinReset().getHref(), otp, new DataLoadListener() {
                             @Override
                             public void onDataLoad(Object result) {
-                                YonaApplication.getUserPreferences().edit().putBoolean(PreferenceConstant.USER_BLOCKED, false).commit();
+                                updatePreferenceForPinReset();
                                 authNetwork.doClearPin(authenticateDao.getUser().getLinks().getClearPinReset().getHref());
                                 listener.onDataLoad(result);
                             }
@@ -218,6 +218,13 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
         }
     }
 
+    private void updatePreferenceForPinReset() {
+        SharedPreferences.Editor editor = YonaApplication.getUserPreferences().edit();
+        editor.putBoolean(PreferenceConstant.USER_BLOCKED, false);
+        editor.putBoolean(PreferenceConstant.STEP_OTP, true);
+        editor.putBoolean(PreferenceConstant.STEP_PASSCODE, false);
+        editor.commit();
+    }
     @Override
     public void requestPinReset(final DataLoadListener listener) {
         try {

--- a/app/src/main/java/nu/yona/app/ui/pincode/PinActivity.java
+++ b/app/src/main/java/nu/yona/app/ui/pincode/PinActivity.java
@@ -167,6 +167,7 @@ public class PinActivity extends BaseActivity implements EventChangeListener {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
                             dialogInterface.dismiss();
+                            YonaApplication.getEventChangeManager().notifyChange(EventChangeManager.EVENT_CLOSE_YONA_ACTIVITY, null);
                             loadOTPScreen();
                         }
                     });


### PR DESCRIPTION
When user is on sms validation screen, without entering OTP user kills the app and then re-opens the app user is shown the launching screen

Signed-off-by: Kinnar Vasa <kvasa@mobiquityinc.com>