### PR TITLE
APPDEV-534

### DIFF
--- a/app/src/main/res/layout/detail_pager_fragment.xml
+++ b/app/src/main/res/layout/detail_pager_fragment.xml
@@ -59,7 +59,7 @@
 
             <nu.yona.app.customview.YonaFontTextView
                 android:id="@+id/date"
-                style="@style/Date"
+                style="@style/DateSixtyOpacity"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"


### PR DESCRIPTION
Title 'today' (vandaag) should have 60% opacity (see me day page in app for correct typography).
Space between Labels not equally distributed.

Signed-off-by: Kinnar Vasa <kvasa@mobiquityinc.com>