### PR TITLE
APPDEV-541

### DIFF
--- a/app/src/main/res/layout/timebucket_graph_layout.xml
+++ b/app/src/main/res/layout/timebucket_graph_layout.xml
@@ -9,7 +9,6 @@
 <nu.yona.app.customview.graph.TimeBucketGraph xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/timeBucketGraph"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/sixty_four"
-    android:layout_marginTop="@dimen/five">
+    android:layout_height="@dimen/sixty_four">
 
 </nu.yona.app.customview.graph.TimeBucketGraph>


### PR DESCRIPTION
On timebucket score element there is to much margin below title. Compare with margin below title of timezone score element.

Signed-off-by: Kinnar Vasa <kvasa@mobiquityinc.com>