### PR TITLE
Puts the URL and password correctly in the email

### DIFF
--- a/app/src/main/java/nu/yona/app/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/settings/SettingsFragment.java
@@ -231,8 +231,8 @@ public class SettingsFragment extends BaseFragment {
                 getString(R.string.yes), getString(R.string.no), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        String userCredential = Html.fromHtml("<html> Base URL:" + YonaApplication.getEventChangeManager().getDataState().getUser().getLinks().getSelf().getHref()
-                                + "<br>" + "Password: " + YonaApplication.getEventChangeManager().getSharedPreference().getYonaPassword() + "</html>").toString();
+                        String userCredential = Html.fromHtml("<html> Base URL: " +Uri.encode( YonaApplication.getEventChangeManager().getDataState().getUser().getLinks().getSelf().getHref())
+                                + "<br><br>" + Uri.encode("Password: " + YonaApplication.getEventChangeManager().getSharedPreference().getYonaPassword()) + "</html>").toString();
                         showEmailClient(userCredential);
                     }
                 }, new DialogInterface.OnClickListener() {


### PR DESCRIPTION
This patch fixes APPDEV-1074 and APPDEV-1076.

Till now, the Android app was putting the URL and password directly into the HTML, without any encoding. Due to that, the URL is only partially available and the password is missing entirely. This makes it impossible to support Android users that report a server-related problem.

Please take this PR and include it in the upcoming Android release.