### PR TITLE
APPDEV-1164 Send app exceptions to crashlytics

### DIFF
--- a/app/docs/index-files/index-20.html
+++ b/app/docs/index-files/index-20.html
@@ -676,7 +676,7 @@ or to a theme attribute in the form "<code>?[<i>package</i>:][<i>type</i>:]<i>na
 <dd>&nbsp;</dd>
 <dt><span class="memberNameLink"><a href="../nu/yona/app/R.dimen.html#thirty_two">thirty_two</a></span> - Static variable in class nu.yona.app.<a href="../nu/yona/app/R.dimen.html" title="class in nu.yona.app">R.dimen</a></dt>
 <dd>&nbsp;</dd>
-<dt><span class="memberNameLink"><a href="../nu/yona/app/utils/AppUtils.html#throwException-java.lang.String-java.lang.Exception-java.lang.Thread-nu.yona.app.listener.DataLoadListener-">throwException(String, Exception, Thread, DataLoadListener)</a></span> - Static method in class nu.yona.app.utils.<a href="../nu/yona/app/utils/AppUtils.html" title="class in nu.yona.app.utils">AppUtils</a></dt>
+<dt><span class="memberNameLink"><a href="../nu/yona/app/utils/AppUtils.html#reportException-java.lang.String-java.lang.Exception-java.lang.Thread-nu.yona.app.listener.DataLoadListener-">reportException(String, Exception, Thread, DataLoadListener)</a></span> - Static method in class nu.yona.app.utils.<a href="../nu/yona/app/utils/AppUtils.html" title="class in nu.yona.app.utils">AppUtils</a></dt>
 <dd>
 <div class="block">Throw exception.</div>
 </dd>

--- a/app/docs/nu/yona/app/utils/AppUtils.html
+++ b/app/docs/nu/yona/app/utils/AppUtils.html
@@ -204,11 +204,11 @@ extends java.lang.Object</pre>
 </tr>
 <tr id="i9" class="rowColor">
 <td class="colFirst"><code>static void</code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../../nu/yona/app/utils/AppUtils.html#throwException-java.lang.String-java.lang.Exception-java.lang.Thread-nu.yona.app.listener.DataLoadListener-">throwException</a></span>(java.lang.String&nbsp;className,
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../nu/yona/app/utils/AppUtils.html#reportException-java.lang.String-java.lang.Exception-java.lang.Thread-nu.yona.app.listener.DataLoadListener-">reportException</a></span>(java.lang.String&nbsp;className,
               java.lang.Exception&nbsp;e,
               java.lang.Thread&nbsp;t,
               <a href="../../../../nu/yona/app/listener/DataLoadListener.html" title="interface in nu.yona.app.listener">DataLoadListener</a>&nbsp;listener)</code>
-<div class="block">Throw exception.</div>
+<div class="block">Reports exception to user and Crashlytics.</div>
 </td>
 </tr>
 </table>
@@ -380,13 +380,13 @@ extends java.lang.Object</pre>
 </dl>
 </li>
 </ul>
-<a name="throwException-java.lang.String-java.lang.Exception-java.lang.Thread-nu.yona.app.listener.DataLoadListener-">
+<a name="reportException-java.lang.String-java.lang.Exception-java.lang.Thread-nu.yona.app.listener.DataLoadListener-">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>throwException</h4>
-<pre>public static&nbsp;void&nbsp;throwException(java.lang.String&nbsp;className,
+<h4>reportException</h4>
+<pre>public static&nbsp;void&nbsp;reportException(java.lang.String&nbsp;className,
                                   java.lang.Exception&nbsp;e,
                                   java.lang.Thread&nbsp;t,
                                   <a href="../../../../nu/yona/app/listener/DataLoadListener.html" title="interface in nu.yona.app.listener">DataLoadListener</a>&nbsp;listener)</pre>

--- a/app/src/main/java/nu/yona/app/YonaApplication.java
+++ b/app/src/main/java/nu/yona/app/YonaApplication.java
@@ -24,6 +24,8 @@ import java.util.Locale;
 import nu.yona.app.analytics.AnalyticsConstant;
 import nu.yona.app.state.EventChangeManager;
 import nu.yona.app.ui.Foreground;
+import nu.yona.app.ui.settings.SettingsFragment;
+import nu.yona.app.utils.AppUtils;
 
 /**
  * Created by kinnarvasa on 16/03/16.
@@ -99,6 +101,7 @@ public class YonaApplication extends Application {
                 tracker.setAppVersion(pInfo.versionName + mContext.getString(R.string.space) + pInfo.versionCode);
                 tracker.send(new HitBuilders.ScreenViewBuilder().build());
             } catch (PackageManager.NameNotFoundException e) {
+                AppUtils.reportException(YonaApplication.class.getSimpleName(), e, Thread.currentThread(), null);
                 nu.yona.app.utils.Logger.loge(YonaApplication.class.getSimpleName(), e.getMessage());
             }
 

--- a/app/src/main/java/nu/yona/app/api/db/DatabaseHelper.java
+++ b/app/src/main/java/nu/yona/app/api/db/DatabaseHelper.java
@@ -65,7 +65,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             db.execSQL(getDBHelper().TABLE_GOAL);
             db.execSQL(getDBHelper().TABLE_ACTIVITY_TRACKER);
         } catch (Exception e) {
-            AppUtils.throwException(DatabaseHelper.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(DatabaseHelper.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 
@@ -81,7 +81,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             mInstance.getWritableDatabase().execSQL("DROP TABLE IF EXISTS " + DBConstant.TBL_ACTIVITY_TRACKER);
             createTables(mInstance.getWritableDatabase());
         } catch (Exception e) {
-            AppUtils.throwException(DatabaseHelper.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(DatabaseHelper.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/api/db/JsonSerializer.java
+++ b/app/src/main/java/nu/yona/app/api/db/JsonSerializer.java
@@ -40,7 +40,7 @@ public class JsonSerializer implements DbSerializer {
         try {
             return mapper.writeValueAsBytes(obj);
         } catch (IOException e) {
-            AppUtils.throwException(JsonSerializer.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(JsonSerializer.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return new byte[0];
     }

--- a/app/src/main/java/nu/yona/app/api/manager/dao/ActivityCategoriesDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/ActivityCategoriesDAO.java
@@ -56,7 +56,7 @@ public class ActivityCategoriesDAO extends BaseDAO {
                 listener.onDataLoad(activityCategories);
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityCategories.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(ActivityCategories.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -75,7 +75,7 @@ public class ActivityCategoriesDAO extends BaseDAO {
                 }
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityCategories.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityCategories.class.getSimpleName(), e, Thread.currentThread(), null);
         } finally {
             if (c != null) {
                 c.close();

--- a/app/src/main/java/nu/yona/app/api/manager/dao/ActivityTrackerDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/ActivityTrackerDAO.java
@@ -71,7 +71,7 @@ public class ActivityTrackerDAO extends BaseDAO {
                 } while (c.moveToNext());
             }
         } catch (Exception e) {
-            AppUtils.throwException(GoalDAO.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(GoalDAO.class.getSimpleName(), e, Thread.currentThread(), null);
         } finally {
             if (c != null) {
                 c.close();

--- a/app/src/main/java/nu/yona/app/api/manager/dao/AuthenticateDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/AuthenticateDAO.java
@@ -59,7 +59,7 @@ public class AuthenticateDAO extends BaseDAO {
                 listener.onDataLoad(getUser());
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateDAO.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateDAO.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -78,7 +78,7 @@ public class AuthenticateDAO extends BaseDAO {
                 }
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityCategories.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityCategories.class.getSimpleName(), e, Thread.currentThread(), null);
         } finally {
             if (c != null) {
                 c.close();

--- a/app/src/main/java/nu/yona/app/api/manager/dao/BaseDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/BaseDAO.java
@@ -118,7 +118,7 @@ class BaseDAO {
                 }
             }.executeAsync();
         } catch (Exception e) {
-            AppUtils.throwException(BaseDAO.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(BaseDAO.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 }

--- a/app/src/main/java/nu/yona/app/api/manager/dao/GoalDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/GoalDAO.java
@@ -54,7 +54,7 @@ public class GoalDAO extends BaseDAO {
                 listener.onDataLoad(getUserGoal());
             }
         } catch (Exception e) {
-            AppUtils.throwException(GoalDAO.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(GoalDAO.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -73,7 +73,7 @@ public class GoalDAO extends BaseDAO {
                 }
             }
         } catch (Exception e) {
-            AppUtils.throwException(GoalDAO.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(GoalDAO.class.getSimpleName(), e, Thread.currentThread(), null);
         } finally {
             if (c != null) {
                 c.close();

--- a/app/src/main/java/nu/yona/app/api/manager/impl/ActivityCategoryManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/ActivityCategoryManagerImpl.java
@@ -78,7 +78,7 @@ public class ActivityCategoryManagerImpl implements ActivityCategoryManager {
         try {
             activityCategoriesDAO.saveActivityCategories(((ActivityCategories) result), listener);
         } catch (Exception e) {
-            AppUtils.throwException(ActivityCategoryManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(ActivityCategoryManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
         return null; // No value to return from here
     }
@@ -92,7 +92,7 @@ public class ActivityCategoryManagerImpl implements ActivityCategoryManager {
         try {
             activityCategoriesNetwork.getActivityCategories(listener);
         } catch (Exception e) {
-            AppUtils.throwException(ActivityCategoryManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(ActivityCategoryManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 }

--- a/app/src/main/java/nu/yona/app/api/manager/impl/ActivityManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/ActivityManagerImpl.java
@@ -62,6 +62,7 @@ import nu.yona.app.enums.GoalsEnum;
 import nu.yona.app.enums.WeekDayEnum;
 import nu.yona.app.listener.DataLoadListener;
 import nu.yona.app.listener.DataLoadListenerImpl;
+import nu.yona.app.ui.YonaActivity;
 import nu.yona.app.utils.AppConstant;
 import nu.yona.app.utils.AppUtils;
 import nu.yona.app.utils.DateUtility;
@@ -135,7 +136,7 @@ public class ActivityManagerImpl implements ActivityManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -179,7 +180,7 @@ public class ActivityManagerImpl implements ActivityManager {
                 }
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return null;
     }
@@ -269,7 +270,7 @@ public class ActivityManagerImpl implements ActivityManager {
                 }
             }
         }catch (NullPointerException e){
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return null;
     }
@@ -282,7 +283,7 @@ public class ActivityManagerImpl implements ActivityManager {
         try {
             activityTrackerDAO.saveActivities(getAppActivity(applicationName, startDate, endDate));
         } catch (Exception e) {
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 
@@ -562,7 +563,7 @@ public class ActivityManagerImpl implements ActivityManager {
                         break;
                     }
                 } catch (Exception e) {
-                    AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+                    AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
                 }
             }
         }
@@ -582,7 +583,7 @@ public class ActivityManagerImpl implements ActivityManager {
                         break;
                     }
                 } catch (Exception e) {
-                    AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+                    AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
                 }
             }
         }
@@ -618,7 +619,7 @@ public class ActivityManagerImpl implements ActivityManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -646,7 +647,7 @@ public class ActivityManagerImpl implements ActivityManager {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -673,7 +674,7 @@ public class ActivityManagerImpl implements ActivityManager {
                             try {
                                 activity.setStickyTitle(DateUtility.getRetriveWeek(overview.getDate()));
                             } catch (Exception e) {
-                                AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+                                AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
                             }
                             activity.setDate(overview.getDate());
                             activity = getWeekDayActivity(activity);
@@ -710,7 +711,7 @@ public class ActivityManagerImpl implements ActivityManager {
             try {
                 weekActivity.setStickyTitle(DateUtility.getRetriveWeek(weekActivity.getDate()));
             } catch (Exception e) {
-                AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+                AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
             }
             weekActivity.setDate(weekActivity.getDate());
             weekActivity = getWeekDayActivity(weekActivity);
@@ -726,7 +727,7 @@ public class ActivityManagerImpl implements ActivityManager {
                 weekActivity.setTotalActivityDurationMinutes(resultActivity.getTotalActivityDurationMinutes());
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         if (listener != null) {
             listener.onDataLoad(weekActivity);
@@ -859,7 +860,7 @@ public class ActivityManagerImpl implements ActivityManager {
                             futureCalendar.setTime(sdf.parse(createdTime));
                             activity.setStickyTitle(DateUtility.getRelativeDate(futureCalendar));
                         } catch (Exception e) {
-                            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+                            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
                             Logger.loge(NotificationManagerImpl.class.getName(), "DateFormat " + e);
                         }
                         // TODO: History check need to ve verify. Concern Issue: http://jira.yona.nu/browse/APPDEV-999.
@@ -1104,7 +1105,7 @@ public class ActivityManagerImpl implements ActivityManager {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -1117,7 +1118,7 @@ public class ActivityManagerImpl implements ActivityManager {
             dayActivity.setStickyTitle(DateUtility.getRelativeDate(futureCalendar));
             return dayActivity;
         } catch (ParseException e) {
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return null;
     }
@@ -1177,7 +1178,7 @@ public class ActivityManagerImpl implements ActivityManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.no_data_found)));
             }
         }catch (NullPointerException e){
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -1207,6 +1208,7 @@ public class ActivityManagerImpl implements ActivityManager {
             futureCalendar.setTime(sdf.parse(createdTime));
             activity.setStickyTitle(DateUtility.getRelativeDate(futureCalendar));
         } catch (Exception e) {
+            AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
             Logger.loge(NotificationManagerImpl.class.getName(), "DateFormat " + e);
         }
         listener.onDataLoad(generateTimeZoneSpread(activity));
@@ -1233,13 +1235,13 @@ public class ActivityManagerImpl implements ActivityManager {
                                                     break;
                                                 }
                                             } catch (Exception e) {
-                                                AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+                                                AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
                                             }
                                         }
                                     }
                                 }
                             } catch (Exception e) {
-                                AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+                                AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
                             }
                         }
                     }

--- a/app/src/main/java/nu/yona/app/api/manager/impl/AuthenticateManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/AuthenticateManagerImpl.java
@@ -115,7 +115,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -245,7 +245,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 });
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -272,7 +272,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 verifyOTPAfterUser(otp, listener);
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -340,7 +340,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 listener.onError(new ErrorMessage(YonaApplication.getAppContext().getString(R.string.invalidotp)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -378,7 +378,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -400,7 +400,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -435,7 +435,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 }
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
 
     }
@@ -467,7 +467,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 }
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -495,7 +495,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 resendOTPAfterUser(listener);
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -544,7 +544,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 OverrideUser(listener);
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -588,7 +588,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/api/manager/impl/BuddyManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/BuddyManagerImpl.java
@@ -108,7 +108,7 @@ public class BuddyManagerImpl implements BuddyManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(BuddyManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(BuddyManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -143,7 +143,7 @@ public class BuddyManagerImpl implements BuddyManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(BuddyManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(BuddyManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -194,7 +194,7 @@ public class BuddyManagerImpl implements BuddyManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(BuddyManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(BuddyManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 }

--- a/app/src/main/java/nu/yona/app/api/manager/impl/ChallengesManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/ChallengesManagerImpl.java
@@ -163,7 +163,7 @@ public class ChallengesManagerImpl implements ChallengesManager {
                 }
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityCategoryManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityCategoryManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return false;
     }

--- a/app/src/main/java/nu/yona/app/api/manager/impl/DeviceManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/DeviceManagerImpl.java
@@ -119,7 +119,7 @@ public class DeviceManagerImpl implements DeviceManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -150,7 +150,7 @@ public class DeviceManagerImpl implements DeviceManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -184,7 +184,7 @@ public class DeviceManagerImpl implements DeviceManager {
                         }
                     });
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -211,7 +211,7 @@ public class DeviceManagerImpl implements DeviceManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
 
     }

--- a/app/src/main/java/nu/yona/app/api/manager/impl/GoalManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/GoalManagerImpl.java
@@ -72,7 +72,7 @@ public class GoalManagerImpl implements GoalManager {
                 listener.onError(mContext.getString(R.string.urlnotfound));
             }
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -99,7 +99,7 @@ public class GoalManagerImpl implements GoalManager {
                 listener.onError(mContext.getString(R.string.urlnotfound));
             }
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -126,7 +126,7 @@ public class GoalManagerImpl implements GoalManager {
                 listener.onError(mContext.getString(R.string.urlnotfound));
             }
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -153,7 +153,7 @@ public class GoalManagerImpl implements GoalManager {
                 listener.onError(mContext.getString(R.string.urlnotfound));
             }
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -176,7 +176,7 @@ public class GoalManagerImpl implements GoalManager {
                 listener.onError(mContext.getString(R.string.urlnotfound));
             }
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -199,7 +199,7 @@ public class GoalManagerImpl implements GoalManager {
                 listener.onError(mContext.getString(R.string.urlnotfound));
             }
         } catch (Exception e) {
-            AppUtils.throwException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/api/manager/impl/NotificationManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/NotificationManagerImpl.java
@@ -131,7 +131,7 @@ public class NotificationManagerImpl implements NotificationManager {
                                                     uploadDate = DateUtility.getRelativeDate(futureCalendar);
                                                     message.setStickyTitle(uploadDate);
                                                 } catch (Exception e) {
-                                                    AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+                                                    AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), null);
                                                 }
                                                 yonaMessages.setEmbedded(embedded);
                                                 if (!isProcessUpdate && message != null && message.getLinks() != null && message.getLinks().getYonaPreocess() != null
@@ -161,7 +161,7 @@ public class NotificationManagerImpl implements NotificationManager {
                 listener.onError(new ErrorMessage(mContext.getString(R.string.urlnotfound)));
             }
         } catch (Exception e) {
-            AppUtils.throwException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -196,7 +196,7 @@ public class NotificationManagerImpl implements NotificationManager {
             String uploadDate = DateUtility.getRelativeDate(futureCalendar);
             return uploadDate;
         }catch(ParseException parseEx) {
-            AppUtils.throwException(ActivityManagerImpl.class.getSimpleName(), parseEx, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), parseEx, Thread.currentThread(), null);
         }
         return null;
     }
@@ -206,7 +206,7 @@ public class NotificationManagerImpl implements NotificationManager {
             DataLoadListenerImpl dataloadListenerImpl =  new DataLoadListenerImpl((result)->processYonaMessages((YonaMessages) result),listener);
             notificationNetwork.getNextSetOfMessagesFromURL(urlForMessagesFetch, YonaApplication.getEventChangeManager().getSharedPreference().getYonaPassword(), isUnreadStatus,dataloadListenerImpl);
         } catch (IllegalArgumentException e) {
-            AppUtils.throwException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -259,7 +259,7 @@ public class NotificationManagerImpl implements NotificationManager {
                 });
             }
         } catch (Exception e) {
-            AppUtils.throwException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -292,7 +292,7 @@ public class NotificationManagerImpl implements NotificationManager {
                 });
             }
         } catch (Exception e) {
-            AppUtils.throwException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -310,7 +310,7 @@ public class NotificationManagerImpl implements NotificationManager {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -341,7 +341,7 @@ public class NotificationManagerImpl implements NotificationManager {
                 }
             }
         } catch (Exception e) {
-            AppUtils.throwException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         } finally {
             listener.onDataLoad(yonaMessageList);
         }

--- a/app/src/main/java/nu/yona/app/api/manager/network/ActivityNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/ActivityNetworkImpl.java
@@ -41,7 +41,7 @@ public class ActivityNetworkImpl extends BaseImpl {
         try {
             getRestApi().getActivities(nextDayActivittUrl, yonaPassword, Locale.getDefault().toString().replace('_', '-')).enqueue(getEmbeddedYonaActivity(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -56,7 +56,7 @@ public class ActivityNetworkImpl extends BaseImpl {
         try {
             getRestApi().getDayDetailActivity(url, yonaPassword, Locale.getDefault().toString().replace('_', '-')).enqueue(getDayDetailActivity(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -71,7 +71,7 @@ public class ActivityNetworkImpl extends BaseImpl {
         try {
             getRestApi().getActivities(nextWeeksActivityUrl, password, Locale.getDefault().toString().replace('_', '-')).enqueue(getEmbeddedYonaActivity(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -86,7 +86,7 @@ public class ActivityNetworkImpl extends BaseImpl {
         try {
             getRestApi().getWeekDetailActivity(url, yonaPassword, Locale.getDefault().toString().replace('_', '-')).enqueue(getweekDetailActivity(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -103,7 +103,7 @@ public class ActivityNetworkImpl extends BaseImpl {
         try {
             getRestApi().getWithBuddyActivity(url, yonaPassword, Locale.getDefault().toString().replace('_', '-'), itemPerPage, pageNo).enqueue(getEmbeddedYonaActivity(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -119,7 +119,7 @@ public class ActivityNetworkImpl extends BaseImpl {
         try {
             getRestApi().postAppActivity(url, yonaPassword, Locale.getDefault().toString().replace('_', '-'), appActivity).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -127,7 +127,7 @@ public class ActivityNetworkImpl extends BaseImpl {
         try {
             getRestApi().getComments(url, yonaPassword, Locale.getDefault().toString().replace('_', '-')).enqueue(getEmbeddedYonaActivity(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -149,7 +149,7 @@ public class ActivityNetworkImpl extends BaseImpl {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -171,7 +171,7 @@ public class ActivityNetworkImpl extends BaseImpl {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/api/manager/network/AuthenticateNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/AuthenticateNetworkImpl.java
@@ -51,7 +51,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
                 getRestApi().updateRegisterUser(url, password, Locale.getDefault().toString().replace('_', '-'), registerUser).enqueue(getUserCallBack(listener));
             }
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -59,7 +59,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
         try {
             getRestApi().registerUser(url, Locale.getDefault().toString().replace('_', '-'), object).enqueue(getUserCallBack(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -88,7 +88,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
         try {
             getRestApi().readDeepLinkData(url, Locale.getDefault().toString().replace('_', '-')).enqueue(getDeepLinkUserDataCallBack(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -104,7 +104,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
         try {
             getRestApi().overrideRegisterUser(Locale.getDefault().toString().replace('_', '-'), otp, object).enqueue(getUserCallBack(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -119,7 +119,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
         try {
             getRestApi().getUser(url, yonaPassword, Locale.getDefault().toString().replace('_', '-')).enqueue(getUserCallBack(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -135,7 +135,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
         try {
             getRestApi().verifyMobileNumber(url, password, Locale.getDefault().toString().replace('_', '-'), otp).enqueue(getUserCallBack(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -150,7 +150,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
         try {
             getRestApi().resendOTP(url, password, Locale.getDefault().toString().replace('_', '-')).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -164,7 +164,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
         try {
             getRestApi().requestUserOverride(Locale.getDefault().toString().replace('_', '-'), mobileNumber).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -179,7 +179,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
         try {
             getRestApi().deleteUser(url, yonaPassword, Locale.getDefault().toString().replace('_', '-')).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -208,7 +208,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -223,7 +223,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
         try {
             getRestApi().verifyPin(url, YonaApplication.getEventChangeManager().getSharedPreference().getYonaPassword(), Locale.getDefault().toString().replace('_', '-'), new OTPVerficationCode(otp)).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -246,7 +246,7 @@ public class AuthenticateNetworkImpl extends BaseImpl {
                 }
             }));
         } catch (Exception e) {
-            AppUtils.throwException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/api/manager/network/BuddyNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/BuddyNetworkImpl.java
@@ -52,7 +52,7 @@ public class BuddyNetworkImpl extends BaseImpl {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(BuddyNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(BuddyNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -81,7 +81,7 @@ public class BuddyNetworkImpl extends BaseImpl {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(BuddyNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(BuddyNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -96,7 +96,7 @@ public class BuddyNetworkImpl extends BaseImpl {
         try {
             getRestApi().deleteBuddy(url, passwrod, Locale.getDefault().toString().replace('_', '-')).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(BuddyNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(BuddyNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 }

--- a/app/src/main/java/nu/yona/app/api/manager/network/DeviceNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/DeviceNetworkImpl.java
@@ -37,7 +37,7 @@ public class DeviceNetworkImpl extends BaseImpl {
         try {
             getRestApi().addDevice(url, yonaPassword, Locale.getDefault().toString().replace('_', '-'), devicePassword).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(DeviceNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(DeviceNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 
@@ -52,7 +52,7 @@ public class DeviceNetworkImpl extends BaseImpl {
         try {
             getRestApi().deleteDevice(url, yonaPassword,  Locale.getDefault().toString().replace('_', '-')).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(DeviceNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(DeviceNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 
@@ -81,7 +81,7 @@ public class DeviceNetworkImpl extends BaseImpl {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(DeviceNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(DeviceNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 }

--- a/app/src/main/java/nu/yona/app/api/manager/network/GoalNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/GoalNetworkImpl.java
@@ -35,7 +35,7 @@ public class GoalNetworkImpl extends BaseImpl {
         try {
             getRestApi().getUserGoals(url, YonaApplication.getEventChangeManager().getSharedPreference().getYonaPassword(),  Locale.getDefault().toString().replace('_', '-')).enqueue(getGoals(listener));
         } catch (Exception e) {
-            AppUtils.throwException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 
@@ -51,7 +51,7 @@ public class GoalNetworkImpl extends BaseImpl {
         try {
             getRestApi().putUserGoals(url, yonaPassword,  Locale.getDefault().toString().replace('_', '-'), goal).enqueue(getGoals(listener));
         } catch (Exception e) {
-            AppUtils.throwException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 
@@ -67,7 +67,7 @@ public class GoalNetworkImpl extends BaseImpl {
         try {
             getRestApi().putUserGoals(url, yonaPassword,  Locale.getDefault().toString().replace('_', '-'), goal).enqueue(getGoals(listener));
         } catch (Exception e) {
-            AppUtils.throwException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 
@@ -82,7 +82,7 @@ public class GoalNetworkImpl extends BaseImpl {
         try {
             getRestApi().deleteUserGoal(url, yonaPassword,  Locale.getDefault().toString().replace('_', '-')).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 
@@ -98,7 +98,7 @@ public class GoalNetworkImpl extends BaseImpl {
         try {
             getRestApi().updateUserGoal(url, yonaPassword,  Locale.getDefault().toString().replace('_', '-'), "", goal).enqueue(getGoals(listener));
         } catch (Exception e) {
-            AppUtils.throwException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 
@@ -114,7 +114,7 @@ public class GoalNetworkImpl extends BaseImpl {
         try {
             getRestApi().updateUserGoal(url, yonaPassword,  Locale.getDefault().toString().replace('_', '-'), "", goal).enqueue(getGoals(listener));
         } catch (Exception e) {
-            AppUtils.throwException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/api/manager/network/NotificationNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/NotificationNetworkImpl.java
@@ -51,7 +51,7 @@ public class NotificationNetworkImpl extends BaseImpl {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -83,7 +83,7 @@ public class NotificationNetworkImpl extends BaseImpl {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -98,7 +98,7 @@ public class NotificationNetworkImpl extends BaseImpl {
         try {
             getRestApi().deleteMessage(url, password, Locale.getDefault().toString().replace('_', '-')).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -114,7 +114,7 @@ public class NotificationNetworkImpl extends BaseImpl {
         try {
             getRestApi().postMessage(url, password, Locale.getDefault().toString().replace('_', '-'), body).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 
@@ -122,7 +122,7 @@ public class NotificationNetworkImpl extends BaseImpl {
         try {
             getRestApi().getComments(url, password, Locale.getDefault().toString().replace('_', '-')).enqueue(getCall(listener));
         } catch (Exception e) {
-            AppUtils.throwException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+            AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
+++ b/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
@@ -84,6 +84,7 @@ public class YonaReceiver extends BroadcastReceiver {
             NotificationManager notificationManager = (NotificationManager) mContext.getSystemService(mContext.NOTIFICATION_SERVICE);
             notificationManager.notify(0, notification);
         } catch (Exception e) {
+            AppUtils.reportException(YonaReceiver.class.getSimpleName(), e, Thread.currentThread(), null);
             Logger.loge(YonaReceiver.class.getSimpleName(), e.getMessage());
         }
     }

--- a/app/src/main/java/nu/yona/app/api/service/ActivityMonitorService.java
+++ b/app/src/main/java/nu/yona/app/api/service/ActivityMonitorService.java
@@ -68,7 +68,7 @@ public class ActivityMonitorService extends Service {
                 currentApp = am.getRunningAppProcesses().get(0).processName;
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityMonitorService.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityMonitorService.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return currentApp;
     }
@@ -175,7 +175,7 @@ public class ActivityMonitorService extends Service {
                 scheduledFuture = null;
             }
         } catch (Exception e) {
-            AppUtils.throwException(ActivityMonitorService.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(ActivityMonitorService.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/customview/CustomProgressDialog.java
+++ b/app/src/main/java/nu/yona/app/customview/CustomProgressDialog.java
@@ -87,7 +87,7 @@ public class CustomProgressDialog extends Dialog {
                 }
             }, duration);
         } catch (Exception e) {
-            AppUtils.throwException(CustomProgressDialog.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(CustomProgressDialog.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/customview/YonaFontUtils.java
+++ b/app/src/main/java/nu/yona/app/customview/YonaFontUtils.java
@@ -83,7 +83,7 @@ class YonaFontUtils {
             try {
                 typeface = Typeface.createFromAsset(context.getAssets(), "fonts/" + fontname);
             } catch (Exception e) {
-                AppUtils.throwException(YonaFontUtils.class.getSimpleName(), e, Thread.currentThread(), null);
+                AppUtils.reportException(YonaFontUtils.class.getSimpleName(), e, Thread.currentThread(), null);
                 return null;
             }
 

--- a/app/src/main/java/nu/yona/app/security/MyCipher.java
+++ b/app/src/main/java/nu/yona/app/security/MyCipher.java
@@ -72,7 +72,7 @@ public class MyCipher {
             return encrypt(bytesBase64);
         }catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | UnsupportedEncodingException
                 | IllegalBlockSizeException | BadPaddingException | InvalidParameterSpecException | InvalidKeySpecException e) {
-            AppUtils.throwException(MyCipher.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(MyCipher.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return null;
     }
@@ -85,7 +85,7 @@ public class MyCipher {
             return restored_data;
         } catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException
                 | IllegalBlockSizeException | BadPaddingException | InvalidKeySpecException e) {
-            AppUtils.throwException(MyCipher.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(MyCipher.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return null;
     }
@@ -173,7 +173,7 @@ public class MyCipher {
             return  new String(decodedBytes, Charset.forName("UTF8"));
         }  catch (UnsupportedEncodingException | InvalidAlgorithmParameterException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException
                 | IllegalBlockSizeException | BadPaddingException  e) {
-            AppUtils.throwException(MyCipher.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(MyCipher.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return null;
     }

--- a/app/src/main/java/nu/yona/app/security/PRNGFixes.java
+++ b/app/src/main/java/nu/yona/app/security/PRNGFixes.java
@@ -38,6 +38,8 @@ import java.security.SecureRandom;
 import java.security.SecureRandomSpi;
 import java.security.Security;
 
+import nu.yona.app.api.receiver.YonaReceiver;
+import nu.yona.app.utils.AppUtils;
 import nu.yona.app.utils.Logger;
 
 /**
@@ -285,6 +287,7 @@ public final class PRNGFixes {
                 // Log and ignore.
                 Logger.loge(PRNGFixes.class.getSimpleName(),
                         "Failed to mix seed into " + URANDOM_FILE);
+                AppUtils.reportException(PRNGFixes.class.getSimpleName(), e, Thread.currentThread(), null);
             } finally {
                 mSeeded = true;
             }

--- a/app/src/main/java/nu/yona/app/ui/BaseActivity.java
+++ b/app/src/main/java/nu/yona/app/ui/BaseActivity.java
@@ -18,10 +18,12 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import nu.yona.app.R;
+import nu.yona.app.YonaApplication;
 import nu.yona.app.analytics.AnalyticsConstant;
 import nu.yona.app.analytics.Categorizable;
 import nu.yona.app.analytics.YonaAnalytics;
 import nu.yona.app.customview.CustomProgressDialog;
+import nu.yona.app.utils.AppUtils;
 import nu.yona.app.utils.Logger;
 
 /**
@@ -58,6 +60,7 @@ public class BaseActivity extends AppCompatActivity implements Categorizable {
                 progressDialog = null;
             }
         } catch (Exception e) {
+            AppUtils.reportException(BaseActivity.class.getSimpleName(), e, Thread.currentThread(), null);
             Logger.loge(BaseActivity.class.getSimpleName(), e.getMessage());
         }
     }

--- a/app/src/main/java/nu/yona/app/ui/YonaActivity.java
+++ b/app/src/main/java/nu/yona/app/ui/YonaActivity.java
@@ -356,6 +356,7 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
                         }
                     });
                 } catch (Exception e) {
+                    AppUtils.reportException(YonaActivity.class.getSimpleName(), e, Thread.currentThread(), null);
                     Logger.loge(YonaActivity.class.getSimpleName(), e.getMessage());
                 }
             } else {
@@ -467,6 +468,7 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
             FileOutputStream fos = new FileOutputStream(file);
             imageBitmap.compress(Bitmap.CompressFormat.JPEG, 100, fos);
         } catch (FileNotFoundException ex) {
+            AppUtils.reportException(YonaActivity.class.getSimpleName(), ex, Thread.currentThread(), null);
             return null;
         }
         return file;
@@ -917,6 +919,7 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
             }
             super.onBackPressed();
         } catch (Exception e) {
+            AppUtils.reportException(YonaActivity.class.getSimpleName(), e, Thread.currentThread(), null);
             Logger.loge(YonaActivity.class.getSimpleName(), e.getMessage());
         }
     }
@@ -1033,7 +1036,7 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
                     }
                     phoneCur.close();
                 } catch (Exception e) {
-                    AppUtils.throwException(YonaActivity.class.getSimpleName(), e, Thread.currentThread(), null);
+                    AppUtils.reportException(YonaActivity.class.getSimpleName(), e, Thread.currentThread(), null);
                 }
                 return null;
             }

--- a/app/src/main/java/nu/yona/app/ui/comment/CommentsAdapter.java
+++ b/app/src/main/java/nu/yona/app/ui/comment/CommentsAdapter.java
@@ -21,6 +21,7 @@ import java.util.List;
 import nu.yona.app.R;
 import nu.yona.app.YonaApplication;
 import nu.yona.app.api.model.YonaMessage;
+import nu.yona.app.utils.AppUtils;
 
 /**
  * Created by bhargavsuthar on 28/07/16.
@@ -78,6 +79,7 @@ public class CommentsAdapter extends RecyclerView.Adapter<CommentHolder> {
                             holder.getProfileImageTxt().setBackground(ContextCompat.getDrawable(mContext, R.drawable.bg_small_self_round));
                         }
                     } catch (Exception e) {
+                        AppUtils.reportException(CommentsAdapter.class.getSimpleName(), e, Thread.currentThread(), null);
                         holder.getProfileImageTxt().setBackground(ContextCompat.getDrawable(mContext, R.drawable.bg_small_friend_round));
                     }
 
@@ -106,6 +108,7 @@ public class CommentsAdapter extends RecyclerView.Adapter<CommentHolder> {
                             holder.getProfileImageTxt().setBackground(ContextCompat.getDrawable(mContext, R.drawable.bg_small_self_round));
                         }
                     } catch (Exception e) {
+                        AppUtils.reportException(CommentsAdapter.class.getSimpleName(), e, Thread.currentThread(), null);
                         holder.getProfileImageTxt().setBackground(ContextCompat.getDrawable(mContext, R.drawable.bg_small_friend_round));
                     }
                 }

--- a/app/src/main/java/nu/yona/app/ui/dashboard/DayActivityDetailFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/dashboard/DayActivityDetailFragment.java
@@ -286,7 +286,7 @@ public class DayActivityDetailFragment extends BaseFragment implements EventChan
                         dayActivityList.add(embeddedYonaActivity.getDayActivityList().get(i));
                     }
                 } catch (Exception e) {
-                    AppUtils.throwException(DayActivityDetailFragment.class.getSimpleName(), e, Thread.currentThread(), null);
+                    AppUtils.reportException(DayActivityDetailFragment.class.getSimpleName(), e, Thread.currentThread(), null);
                 }
             }
             int itemIndex = getIndex(activity);

--- a/app/src/main/java/nu/yona/app/ui/dashboard/PerDayFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/dashboard/PerDayFragment.java
@@ -80,7 +80,7 @@ public class PerDayFragment extends BaseFragment {
                     }
                 }
             } catch (Exception e) {
-                AppUtils.throwException(PerDayFragment.class.getSimpleName(), e, Thread.currentThread(), null);
+                AppUtils.reportException(PerDayFragment.class.getSimpleName(), e, Thread.currentThread(), null);
             }
         }
     };

--- a/app/src/main/java/nu/yona/app/ui/dashboard/PerWeekFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/dashboard/PerWeekFragment.java
@@ -79,7 +79,7 @@ public class PerWeekFragment extends BaseFragment {
                     }
                 }
             } catch (Exception e) {
-                AppUtils.throwException(PerWeekFragment.class.getSimpleName(), e, Thread.currentThread(), null);
+                AppUtils.reportException(PerWeekFragment.class.getSimpleName(), e, Thread.currentThread(), null);
             }
         }
     };

--- a/app/src/main/java/nu/yona/app/ui/dashboard/WeekActivityDetailFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/dashboard/WeekActivityDetailFragment.java
@@ -310,7 +310,7 @@ public class WeekActivityDetailFragment extends BaseFragment implements EventCha
             }
             setDayDetailTitleAndIcon();
         } catch (NullPointerException e) {
-            AppUtils.throwException(WeekActivityDetailFragment.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(WeekActivityDetailFragment.class.getSimpleName(), e, Thread.currentThread(), null);
         }
         return null;
     }

--- a/app/src/main/java/nu/yona/app/ui/frinends/TimelineFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/frinends/TimelineFragment.java
@@ -78,7 +78,7 @@ public class TimelineFragment extends BaseFragment implements EventChangeListene
                     }
                 }
             } catch (Exception e) {
-                AppUtils.throwException(TimelineFragment.class.getSimpleName(), e, Thread.currentThread(), null);
+                AppUtils.reportException(TimelineFragment.class.getSimpleName(), e, Thread.currentThread(), null);
             }
         }
     };

--- a/app/src/main/java/nu/yona/app/ui/message/NotificationFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/message/NotificationFragment.java
@@ -126,6 +126,7 @@ public class NotificationFragment extends BaseFragment {
 
                         mMessageIntent.putExtra(AppConstant.EVENT_TIME, calendar.get(Calendar.HOUR) + ":" + calendar.get(Calendar.MINUTE));
                     } catch (Exception e) {
+                        AppUtils.reportException(NotificationFragment.class.getSimpleName(), e, Thread.currentThread(), null);
                         Logger.printStackTrace(e);
                     }
 
@@ -312,7 +313,7 @@ public class NotificationFragment extends BaseFragment {
             DataLoadListenerImpl dataLoadListenerImpl =  new DataLoadListenerImpl(((result) -> handleYonaMessagesFetchSuccess((YonaMessages) result)), ((result) ->handleYonaMessagesFetchFailure(result)),null);
             APIManager.getInstance().getNotificationManager().getMessages(urlForMessageFetch,false, dataLoadListenerImpl);
         }catch (IllegalArgumentException e ) {
-            AppUtils.throwException(NotificationFragment.class.getSimpleName(),e,Thread.currentThread(),null);
+            AppUtils.reportException(NotificationFragment.class.getSimpleName(),e,Thread.currentThread(),null);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/settings/SettingsFragment.java
@@ -183,7 +183,7 @@ public class SettingsFragment extends BaseFragment {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(SettingsFragment.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(SettingsFragment.class.getSimpleName(), e, Thread.currentThread(), null);
             showAlert(e.toString(), false);
         }
     }
@@ -204,6 +204,7 @@ public class SettingsFragment extends BaseFragment {
                         .show();
             }
         } catch (Exception e) {
+            AppUtils.reportException(SettingsFragment.class.getSimpleName(), e, Thread.currentThread(), null);
             Log.e(SettingsFragment.class.getSimpleName(), e.getMessage());
         }
     }
@@ -222,7 +223,7 @@ public class SettingsFragment extends BaseFragment {
                 }
             });
         } catch (Exception e) {
-            AppUtils.throwException(SettingsFragment.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(SettingsFragment.class.getSimpleName(), e, Thread.currentThread(), null);
             showAlert(e.toString(), false);
         }
     }

--- a/app/src/main/java/nu/yona/app/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/settings/SettingsFragment.java
@@ -86,11 +86,7 @@ public class SettingsFragment extends BaseFragment {
             }
         });
         AppMetaInfo appMetaInfo = AppMetaInfo.getInstance();
-        if(appMetaInfo.getAppVersionCode() != 0){
-            ((TextView) view.findViewById(R.id.label_version)).setText(getString(R.string.version) + appMetaInfo.getAppVersion() + getString(R.string.space) + appMetaInfo.getAppVersionCode());
-        }else{
-            ((TextView) view.findViewById(R.id.label_version)).setText(getString(R.string.version) + "NA" + getString(R.string.space) + "NA");
-        }
+        ((TextView) view.findViewById(R.id.label_version)).setText(getString(R.string.version) + appMetaInfo.getAppVersion() + getString(R.string.space) + appMetaInfo.getAppVersionCode());
         setHook(new YonaAnalytics.BackHook(AnalyticsConstant.BACK_FROM_SCREEN_SETTINGS));
         return view;
     }

--- a/app/src/main/java/nu/yona/app/ui/signup/StepTwoFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/signup/StepTwoFragment.java
@@ -42,6 +42,8 @@ import nu.yona.app.customview.YonaPhoneWatcher;
 import nu.yona.app.state.EventChangeListener;
 import nu.yona.app.state.EventChangeManager;
 import nu.yona.app.ui.BaseFragment;
+import nu.yona.app.ui.YonaActivity;
+import nu.yona.app.utils.AppUtils;
 import nu.yona.app.utils.Logger;
 import nu.yona.app.utils.MobileNumberFormatter;
 
@@ -112,6 +114,7 @@ public class StepTwoFragment extends BaseFragment implements EventChangeListener
                 mobileNumber.setText(number.substring(ccode.length(), number.length()));
 
             } catch (NumberParseException e) {
+                AppUtils.reportException(StepTwoFragment.class.getSimpleName(), e, Thread.currentThread(), null);
                 Logger.loge(TAG, "Exception", e);
             }
         } else {

--- a/app/src/main/java/nu/yona/app/ui/tour/CarrouselViewPager.java
+++ b/app/src/main/java/nu/yona/app/ui/tour/CarrouselViewPager.java
@@ -16,6 +16,8 @@ import android.view.animation.Interpolator;
 
 import java.lang.reflect.Field;
 
+import nu.yona.app.utils.AppUtils;
+
 /**
  * Created by bhargavsuthar on 19/05/16.
  */
@@ -61,6 +63,7 @@ public class CarrouselViewPager extends ViewPager {
                     (Interpolator) interpolator.get(null));
             scroller.set(this, mScroller);
         } catch (Exception e) {
+            AppUtils.reportException(CarrouselViewPager.class.getSimpleName(), e, Thread.currentThread(), null);
         }
     }
 

--- a/app/src/main/java/nu/yona/app/utils/DateUtility.java
+++ b/app/src/main/java/nu/yona/app/utils/DateUtility.java
@@ -69,7 +69,7 @@ public class DateUtility {
                 relativeDate = new SimpleDateFormat("EEEE, d MMM").format(future.getTime());
 
             } catch (Exception e) {
-                AppUtils.throwException(DateUtility.class.getSimpleName(), e, Thread.currentThread(), null);
+                AppUtils.reportException(DateUtility.class.getSimpleName(), e, Thread.currentThread(), null);
             }
         }
 
@@ -148,7 +148,7 @@ public class DateUtility {
                 calendar.add(Calendar.DAY_OF_WEEK, 1);
             }
         } catch (Exception e) {
-            AppUtils.throwException(DateUtility.class.getSimpleName(), e, Thread.currentThread(), null);
+            AppUtils.reportException(DateUtility.class.getSimpleName(), e, Thread.currentThread(), null);
         }
 
         return listOfdates;
@@ -204,6 +204,7 @@ public class DateUtility {
                 }
             } catch (ParseException e) {
                 Logger.loge(TAG, "Exception", e);
+                AppUtils.reportException(DateUtility.class.getSimpleName(), e, Thread.currentThread(), null);
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
- Application will log Exception to Crashlytics.
- Renamed throwException --> AppUtils to reportException.
- App now sends the Exception logs to Crashlytics on next launch of the application.
- Added Crashlytics on every un-handled exception across application.

  Pending correction for APPDEV-1139
- Removing null check for AppMetaData as commented here
        https://github.com/yonadev/yona-app-android/pull/507#discussion_r215729345