### PR TITLE
APPDEV-1189 Send log messages to Crashlytics

### DIFF
--- a/app/src/main/java/nu/yona/app/utils/AppUtils.java
+++ b/app/src/main/java/nu/yona/app/utils/AppUtils.java
@@ -35,8 +35,6 @@ import android.util.TypedValue;
 import android.view.View;
 import android.widget.Toast;
 
-import com.crashlytics.android.Crashlytics;
-
 import org.joda.time.Period;
 
 import java.io.BufferedInputStream;
@@ -297,9 +295,8 @@ public class AppUtils
 		else
 		{
 			showErrorToast(errorMessage);
-			logExceptionToCrashlytics(exception);
+			Logger.loge(className, errorMessage.getMessage(), exception);
 		}
-		Logger.loge(className, errorMessage.getMessage());
 	}
 
 	/**
@@ -325,16 +322,6 @@ public class AppUtils
 	public static void reportException(String className, Exception exception, Thread t)
 	{
 		AppUtils.reportException(className, exception, t, null);
-	}
-
-    /*
-    Method logs Exception to the Crashlytics Dashboard under Non-fatal section.
-    Application uploads the Exceptions only after next launch after event occurs.
-     */
-
-	public static void logExceptionToCrashlytics(Exception exception)
-	{
-		Crashlytics.logException(exception);
 	}
 
 	/**

--- a/app/src/main/java/nu/yona/app/utils/Logger.java
+++ b/app/src/main/java/nu/yona/app/utils/Logger.java
@@ -12,45 +12,64 @@ import android.content.Context;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.crashlytics.android.Crashlytics;
+
+import io.fabric.sdk.android.Fabric;
 import nu.yona.app.BuildConfig;
 
 /**
- * Created by spatni on 15/09/17.
- * A common Logger implementation to support loggin mechanism in application.
+ * A common Logger implementation to support logging mechanism in application.
  */
 
 public class Logger
 {
 
-	public static void logi(String TAG, String message)
+	public static void logi(String tag, String message)
 	{
-		if (BuildConfig.DEBUG)
+		if (Fabric.isInitialized())
 		{
-			Log.i(TAG, message);
+			Crashlytics.log(Log.INFO, tag, message);
+		}
+		else
+		{
+			Log.i(tag, message);
 		}
 	}
 
-	public static void loge(String TAG, String message)
+	public static void loge(String tag, String message)
 	{
-		if (BuildConfig.DEBUG)
+		if (Fabric.isInitialized())
 		{
-			Log.e(TAG, message);
+			Crashlytics.log(Log.ERROR, tag, message);
+		}
+		else
+		{
+			Log.e(tag, message);
 		}
 	}
 
-	public static void loge(String TAG, String message, Exception e)
+	public static void loge(String tag, String message, Exception exception)
 	{
-		if (BuildConfig.DEBUG)
+		if (Fabric.isInitialized())
 		{
-			Log.e(TAG, message, e);
+			Crashlytics.log(Log.ERROR, tag, message);
+			Crashlytics.logException(exception);
+		}
+		else
+		{
+			Log.e(tag, message, exception);
 		}
 	}
 
-	public static void logd(String TAG, String message)
+	public static void logd(String tag, String message)
 	{
-		if (BuildConfig.DEBUG)
+		if (Fabric.isInitialized())
 		{
-			Log.d(TAG, message);
+			Crashlytics.log(Log.DEBUG, tag, message);
+		}
+		else
+		{
+			Log.d(tag, message);
 		}
 	}
 


### PR DESCRIPTION
Crashlytics supports adding log messages to the crash report, which could be of great help when analyzing issues. If Fabric is not initialized, the log messages are issued the classic way. This can occur in early stages of the app and in unit tests.

Log messages reported through reportException are now not logged anymore when they are being passed on to a listener. That's fair, as the listener is responsible for doing the handling of that error. The listener might log it or handle it otherwise.