### PR TITLE
APPDEV-1177 Not allowed to start init in backgournd

### DIFF
--- a/app/src/main/java/nu/yona/app/api/service/ActivityMonitorService.java
+++ b/app/src/main/java/nu/yona/app/api/service/ActivityMonitorService.java
@@ -121,12 +121,12 @@ public class ActivityMonitorService extends Service
 		return START_NOT_STICKY;
 	}
 
-	@TargetApi(26)
+	@TargetApi(Build.VERSION_CODES.O)
 	private void displayActivityMonitoringNotification()
 	{
 		String CHANNEL_ID = "yona-channel";
 		NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
-				"yona activity monitoring channel",
+				this.getString(R.string.notification_channel_name),
 				NotificationManager.IMPORTANCE_MIN);
 		channel.setShowBadge(false);
 		Intent intent = new Intent(this, LaunchActivity.class);
@@ -143,6 +143,7 @@ public class ActivityMonitorService extends Service
 				.build();
 		startForeground(NOTIFICATION_ID, notification);
 	}
+
 
 	private void removeActivityMonitoringNotification()
 	{

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -224,6 +224,6 @@
     <string name="generic_mobile_number_format_error">Ongeldig telefoonnummer. Controleer het formaat</string>
     <string name="yona_notification_content">App-gebruik wordt gemonitord door Yona.</string>
     <string name="notification_disabled_message">Meldingen voor de Yona-applicatie zijn uitgeschakeld door de gebruiker. Geef rechten op in apparaatinstellingen.</string>
-    <string name="notification_channel_name">Yona activiteit monitoring kanaal</string>
+    <string name="notification_channel_name">Yona activiteitmonitoringkanaal</string>
 
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -222,7 +222,8 @@
     <string name="generic_alert_title">Waarschuwing</string>
     <string name="generic_exception_message">Onbekende fout. Neem contact op met Yona support.</string>
     <string name="generic_mobile_number_format_error">Ongeldig telefoonnummer. Controleer het formaat</string>
-    <string name="yona_notification_content">Apparaatapp-activiteit wordt gecontroleerd door Yona</string>
+    <string name="yona_notification_content">App-gebruik wordt gemonitord door Yona.</string>
     <string name="notification_disabled_message">Meldingen voor de Yona-applicatie zijn uitgeschakeld door de gebruiker. Geef rechten op in apparaatinstellingen.</string>
+    <string name="notification_channel_name">Yona activiteit monitoring kanaal</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,7 @@
     <string name="generic_alert_title">Alert</string>
     <string name="generic_exception_message">Unknown Exception. Please contact Yona support</string>
     <string name="generic_mobile_number_format_error">Invalid Mobile Number. Please check the format</string>
-    <string name="yona_notification_content">Device app activity is monitored by Yona</string>
-    <string name="notification_disabled_message">Notifications for Yona application are disabled by User. Please provide permissions in device settings.</string>
+    <string name="yona_notification_content">App usage is monitored by Yona.</string>
+    <string name="notification_disabled_message">Notifications for the Yona application have been disabled by the user. Give permission in device settings.</string>
+    <string name="notification_channel_name">yona-channel</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,5 +226,5 @@
     <string name="generic_mobile_number_format_error">Invalid Mobile Number. Please check the format</string>
     <string name="yona_notification_content">App usage is monitored by Yona.</string>
     <string name="notification_disabled_message">Notifications for the Yona application have been disabled by the user. Give permission in device settings.</string>
-    <string name="notification_channel_name">yona-channel</string>
+    <string name="notification_channel_name">Yona activity monitoring channel</string>
 </resources>


### PR DESCRIPTION
From Android OREO, applications which run some code in background are expected to display a notification till the task is completed.
This change-set will enable application to start fore-ground service with notification to user, starting from Android OS-OREO and above. Behavior in Lower OS versions will remain same.