### PR TITLE
APPDEV-1204 App activity monitoring fix drains battery

### DIFF
--- a/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
+++ b/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
@@ -76,7 +76,7 @@ public class YonaReceiver extends BroadcastReceiver
 		PowerManager powerManager = (PowerManager) context.getSystemService(POWER_SERVICE);
 		if (powerManager.isDeviceIdleMode())
 		{
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+			if (powerManager.isDeviceIdleMode() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
 			{
 				scheduleNextAlarmToCheckIfDeviceIsInteractive(context, INTERACTIVE_CHECK_INTERVAL);
 			}

--- a/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
+++ b/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
@@ -72,7 +72,7 @@ public class YonaReceiver extends BroadcastReceiver
 	@TargetApi(Build.VERSION_CODES.O)
 	private void handleDeviceDozeMode(Context context)
 	{
-		Logger.loge("BroadCast", "ACTION_DEVICE_IDLE_MODE_CHANGED");
+		Logger.loge("Broadcast", "ACTION_DEVICE_IDLE_MODE_CHANGED");
 		PowerManager powerManager = (PowerManager) context.getSystemService(POWER_SERVICE);
 		if (powerManager.isDeviceIdleMode())
 		{
@@ -85,20 +85,20 @@ public class YonaReceiver extends BroadcastReceiver
 
 	private void handleRebootCompletedBroadcast(Context context)
 	{
-		Logger.loge("BroadCast", "ACTION_BOOT_COMPLETED");
+		Logger.loge("Broadcast", "ACTION_BOOT_COMPLETED");
 		startService(context);
 	}
 
 	private void handleScreenOnBroadcast(Context context)
 	{
-		Logger.logi("BroadCast", "ACTION_SCREEN_ON");
+		Logger.logi("Broadcast", "ACTION_SCREEN_ON");
 		startService(context);
 		AppUtils.startVPN(context, false);
 	}
 
 	private void handleScreenOffBroadcast(Context context)
 	{
-		Logger.logi("BroadCast", "ACTION_SCREEN_OFF");
+		Logger.logi("Broadcast", "ACTION_SCREEN_OFF");
 		AppUtils.setNullScheduler();
 		AppUtils.sendLogToServer(AppConstant.ONE_SECOND);
 	}
@@ -106,7 +106,7 @@ public class YonaReceiver extends BroadcastReceiver
 	@TargetApi(Build.VERSION_CODES.O)
 	private void handleWakeUpAlarm(Context context)
 	{
-		Logger.logi("BroadCast", "WAKE_UP");
+		Logger.logi("Broadcast", "WAKE_UP");
 		// Device is awake from doze/sleep (it can be because of user interaction or of some silent Push notifications).
 		// We should start service only when device is interactive else schedule next alarm
 		if (isDeviceInteractive(context))
@@ -141,7 +141,7 @@ public class YonaReceiver extends BroadcastReceiver
 
 	private void handleRestartVPNBroadcast(Context context)
 	{
-		Logger.logi("BroadCast", "Restart VPN Broadcast received");
+		Logger.logi("Broadcast", "Restart VPN Broadcast received");
 		showRestartVPN(context.getString(R.string.vpn_disconnected));
 	}
 

--- a/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
+++ b/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
@@ -61,45 +61,59 @@ public class YonaReceiver extends BroadcastReceiver
 			case AppConstant.RESTART_VPN:
 				handleRestartVPNBroadcast(context);
 				break;
+			case PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED:
+				handleDeviceDozeMode(context);
+				break;
 			default:
 				break;
 		}
 	}
 
+	@TargetApi(Build.VERSION_CODES.O)
+	private void handleDeviceDozeMode(Context context)
+	{
+		Logger.loge("BroadCast", "ACTION_DEVICE_IDLE_MODE_CHANGED");
+		PowerManager powerManager = (PowerManager) context.getSystemService(POWER_SERVICE);
+		if (powerManager.isDeviceIdleMode())
+		{
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+			{
+				scheduleNextAlarmToCheckIfDeviceIsInteractive(context, INTERACTIVE_CHECK_INTERVAL);
+			}
+		}
+	}
+
 	private void handleRebootCompletedBroadcast(Context context)
 	{
-		Logger.loge("ACTION_BOOT_COMPLETED On", "ACTION_BOOT_COMPLETED On");
+		Logger.loge("BroadCast", "ACTION_BOOT_COMPLETED");
 		startService(context);
 	}
 
 	private void handleScreenOnBroadcast(Context context)
 	{
-		Logger.logi("Screen On", "Screen On");
+		Logger.logi("BroadCast", "ACTION_SCREEN_ON");
 		startService(context);
 		AppUtils.startVPN(context, false);
 	}
 
 	private void handleScreenOffBroadcast(Context context)
 	{
-		Logger.logi("SEND_Screen Off", "Screen Off");
+		Logger.logi("BroadCast", "ACTION_SCREEN_OFF");
 		AppUtils.setNullScheduler();
 		AppUtils.sendLogToServer(AppConstant.ONE_SECOND);
-		AppUtils.stopService(context);
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-		{
-			scheduleNextAlarmToCheckIfDeviceIsInteractive(context, INTERACTIVE_CHECK_INTERVAL);
-		}
 	}
 
 	@TargetApi(Build.VERSION_CODES.O)
 	private void handleWakeUpAlarm(Context context)
 	{
+		Logger.logi("BroadCast", "WAKE_UP");
 		// Device is awake from doze/sleep (it can be because of user interaction or of some silent Push notifications).
 		// We should start service only when device is interactive else schedule next alarm
 		if (isDeviceInteractive(context))
 		{
 			startService(context);
 			AppUtils.startVPN(context, false);
+			AppUtils.cancelPendingWakeUpAlarms(context);
 		}
 		else
 		{
@@ -127,7 +141,7 @@ public class YonaReceiver extends BroadcastReceiver
 
 	private void handleRestartVPNBroadcast(Context context)
 	{
-		Logger.logi("VPN", "Restart VPN Broadcast received");
+		Logger.logi("BroadCast", "Restart VPN Broadcast received");
 		showRestartVPN(context.getString(R.string.vpn_disconnected));
 	}
 

--- a/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
+++ b/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
@@ -74,12 +74,9 @@ public class YonaReceiver extends BroadcastReceiver
 	{
 		Logger.loge("Broadcast", "ACTION_DEVICE_IDLE_MODE_CHANGED");
 		PowerManager powerManager = (PowerManager) context.getSystemService(POWER_SERVICE);
-		if (powerManager.isDeviceIdleMode())
+		if (powerManager.isDeviceIdleMode() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
 		{
-			if (powerManager.isDeviceIdleMode() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-			{
-				scheduleNextAlarmToCheckIfDeviceIsInteractive(context, INTERACTIVE_CHECK_INTERVAL);
-			}
+			scheduleNextAlarmToCheckIfDeviceIsInteractive(context, INTERACTIVE_CHECK_INTERVAL);
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/utils/AppUtils.java
+++ b/app/src/main/java/nu/yona/app/utils/AppUtils.java
@@ -30,6 +30,7 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.PowerManager;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v7.app.AlertDialog;
 import android.text.InputFilter;
@@ -261,6 +262,8 @@ public class AppUtils
 		filter.addAction(Intent.ACTION_BOOT_COMPLETED);
 		filter.addAction(AppConstant.RESTART_DEVICE);
 		filter.addAction(AppConstant.RESTART_VPN);
+		filter.addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED);
+
 
 		context.registerReceiver(receiver, filter);
 	}


### PR DESCRIPTION
-- App now has the Foreground service up and running forever, unless stopped by device in Doze mode.
-- After detecting doze mode broadcast, app schedules alarms for every 10 secs interval. Once alarm goes off and if device is interactive, app restarts the service else schedules next alarm.
-- PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED broadcast is received only when app goes to doze mode, but not when it comes out of it because of lack of active context.