### PR TITLE
APPDEV-1208 allow user certificates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,8 @@
         android:largeHeap="true"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:replace="android:allowBackup">
+        tools:replace="android:allowBackup"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
             android:name=".ui.LaunchActivity"
@@ -49,6 +50,7 @@
 
             <intent-filter android:label="@string/appname">
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
@@ -108,8 +110,9 @@
             android:icon="@mipmap/ic_launcher"
             android:label="@string/service_name" />
 
-        <activity android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
-            android:theme="@style/Base.Theme.AppCompat"/>
+        <activity
+            android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+            android:theme="@style/Base.Theme.AppCompat" />
 
         <receiver android:name=".api.receiver.YonaReceiver">
             <intent-filter>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -2,9 +2,8 @@
 <network-security-config>
     <base-config cleartextTrafficPermitted="false" />
     <domain-config>
-        <domain includeSubdomains="true">yona.nu</domain>
+        <domain includeSubdomains="true">*.yona.nu</domain>
         <trust-anchors>
-            <!-- Trust a debug certificate in addition to the system certificates -->
             <certificates src="system" />
             <certificates src="user" />
         </trust-anchors>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -2,7 +2,7 @@
 <network-security-config>
     <base-config cleartextTrafficPermitted="false" />
     <domain-config>
-        <domain includeSubdomains="true">*.yona.nu</domain>
+        <domain includeSubdomains="true">yona.nu</domain>
         <trust-anchors>
             <certificates src="system" />
             <certificates src="user" />

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config>
+        <domain includeSubdomains="true">yona.nu</domain>
+        <trust-anchors>
+            <!-- Trust a debug certificate in addition to the system certificates -->
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
App is enabled to trust all CA certs in User and System locations.
This enables the app ssl traffic to be proxied (eg: Charles). But user needs to install the valid CA to read the encrypted traffic.