### PR TITLE
APPDEV-1226 farbic crash in build 11 171

### DIFF
--- a/app/src/main/java/nu/yona/app/api/service/ActivityMonitorService.java
+++ b/app/src/main/java/nu/yona/app/api/service/ActivityMonitorService.java
@@ -124,16 +124,15 @@ public class ActivityMonitorService extends Service
 	@TargetApi(Build.VERSION_CODES.O)
 	private void displayActivityMonitoringNotification()
 	{
-		String CHANNEL_ID = "yona-channel";
-		NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
-				this.getString(R.string.notification_channel_name),
+		NotificationChannel channel = new NotificationChannel(AppConstant.YONA_VPN_CHANNEL_ID,
+				this.getString(R.string.yona_service_notification_channel_name),
 				NotificationManager.IMPORTANCE_MIN);
 		channel.setShowBadge(false);
 		Intent intent = new Intent(this, LaunchActivity.class);
 		PendingIntent pendingIntent = PendingIntent.getActivity(getApplicationContext(), 0 /* Request code */, intent,
 				PendingIntent.FLAG_UPDATE_CURRENT);
 		((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE)).createNotificationChannel(channel);
-		Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+		Notification notification = new NotificationCompat.Builder(this, AppConstant.YONA_VPN_CHANNEL_ID)
 				.setSmallIcon(R.drawable.ic_launcher)
 				.setContentTitle(this.getString(R.string.yona_notification_content))
 				.setContentIntent(pendingIntent)

--- a/app/src/main/java/nu/yona/app/ui/pincode/BasePasscodeActivity.java
+++ b/app/src/main/java/nu/yona/app/ui/pincode/BasePasscodeActivity.java
@@ -41,6 +41,7 @@ import nu.yona.app.customview.YonaFontTextView;
 import nu.yona.app.listener.DataLoadListenerImpl;
 import nu.yona.app.state.EventChangeManager;
 import nu.yona.app.ui.BaseActivity;
+import nu.yona.app.ui.YonaActivity;
 import nu.yona.app.utils.AppConstant;
 import nu.yona.app.utils.PreferenceConstant;
 
@@ -590,20 +591,19 @@ passcode_reset;
 		{
 			errorMessageStr = (String) errorMessage;
 		}
-		final AlertDialog.Builder builder = new AlertDialog.Builder(this);
+		displayErrorMessageToUser(errorMessageStr);
+		return null;
+	}
+
+
+	private void displayErrorMessageToUser(String errorMessageStr)
+	{
+		final AlertDialog.Builder builder = new AlertDialog.Builder(YonaActivity.getActivity());
 		builder.setTitle(getString(R.string.generic_alert_title));
 		builder.setMessage(errorMessageStr);
-		builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener()
-		{
-			@Override
-			public void onClick(DialogInterface dialog, int which)
-			{
-				navigateToNextScreen();
-			}
-		});
+		builder.setPositiveButton(android.R.string.ok, (DialogInterface dialog, int which) -> navigateToNextScreen());
 		builder.setCancelable(false);
 		builder.create().show();
-		return null;
 	}
 
 	protected abstract void navigateToNextScreen();

--- a/app/src/main/java/nu/yona/app/utils/AppConstant.java
+++ b/app/src/main/java/nu/yona/app/utils/AppConstant.java
@@ -295,4 +295,9 @@ public interface AppConstant
 	String RESTART_VPN = "com.yona.app.RESTART_VPN";
 	String RESTART_DEVICE = "com.yona.app.RESTART_DEVICE";
 	String WAKE_UP = "com.yona.app.WAKE_UP_ALARM";
+
+
+	// Notifications Channel Id's
+	String YONA_VPN_CHANNEL_ID = "Yona-VPN";
+	String YONA_SERVICE_CHANNEL_ID = "yona-channel";
 }

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -225,6 +225,7 @@
     <string name="generic_mobile_number_format_error">Ongeldig telefoonnummer. Controleer het formaat</string>
     <string name="yona_notification_content">Monitort appgebruik</string>
     <string name="notification_disabled_message">Meldingen voor de Yona-applicatie zijn uitgeschakeld door de gebruiker. Geef rechten in apparaatinstellingen.</string>
-    <string name="notification_channel_name">Vaste melding</string>
     <string name="support_mail_subject">Probleem met Yona app</string>
+    <string name="yona_service_notification_channel_name">Vaste melding</string>
+    <string name="yona_vpn_notification_channel_name">VPN-meldingen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,7 @@
     <string name="generic_mobile_number_format_error">Invalid Mobile Number. Please check the format</string>
     <string name="yona_notification_content">Monitoring app usage</string>
     <string name="notification_disabled_message">Notifications for the Yona application have been disabled by the user. Give permission in device settings.</string>
-    <string name="notification_channel_name">Persistent notifications</string>
+    <string name="yona_service_notification_channel_name">Persistent notifications</string>
+    <string name="yona_vpn_notification_channel_name">VPN notifications</string>
     <string name="support_mail_subject">Problem with Yona app</string>
 </resources>


### PR DESCRIPTION
APPDEV-1226 Crash when alerting the failure of openAppEvent API call to the user.

-- App now uses, current active context to display the alert instead of context from activity which might exit from visibility, by the time error response returns.