### PR TITLE
APPDEV-1256 Crash in Per day/week fragments due to http scheme issue.

### DIFF
--- a/app/src/main/java/nu/yona/app/api/manager/AuthenticateManager.java
+++ b/app/src/main/java/nu/yona/app/api/manager/AuthenticateManager.java
@@ -13,6 +13,7 @@ import java.io.File;
 import nu.yona.app.api.model.RegisterUser;
 import nu.yona.app.api.model.User;
 import nu.yona.app.listener.DataLoadListener;
+import nu.yona.app.listener.DataLoadListenerImpl;
 
 /**
  * Created by kinnarvasa on 25/03/16.
@@ -92,6 +93,12 @@ public interface AuthenticateManager
 	 * @param listener the listener
 	 */
 	void getUser(final String url, final DataLoadListener listener);
+
+	/**
+	 * Gets user from server.
+	 */
+	void getUserFromServer(String userSelfLink, DataLoadListenerImpl dataLoadListener);
+
 
 	/**
 	 * Gets friend profile.

--- a/app/src/main/java/nu/yona/app/api/manager/impl/AuthenticateManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/AuthenticateManagerImpl.java
@@ -26,6 +26,7 @@ import nu.yona.app.api.model.ProfilePhoto;
 import nu.yona.app.api.model.RegisterUser;
 import nu.yona.app.api.model.User;
 import nu.yona.app.listener.DataLoadListener;
+import nu.yona.app.listener.DataLoadListenerImpl;
 import nu.yona.app.utils.AppConstant;
 import nu.yona.app.utils.AppUtils;
 import nu.yona.app.utils.MobileNumberFormatter;
@@ -829,6 +830,13 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 			});
 		}
 	}
+
+	@Override
+	public void getUserFromServer(String url, DataLoadListenerImpl dataLoadListener)
+	{
+		getUser(url, dataLoadListener);
+	}
+
 
 	/**
 	 * @param listener

--- a/app/src/main/java/nu/yona/app/api/model/User.java
+++ b/app/src/main/java/nu/yona/app/api/model/User.java
@@ -13,6 +13,8 @@ import android.content.ContentValues;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,6 +23,7 @@ import nu.yona.app.YonaApplication;
 /**
  * The type User.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class User extends BaseEntity
 {
 

--- a/app/src/main/java/nu/yona/app/ui/LaunchActivity.java
+++ b/app/src/main/java/nu/yona/app/ui/LaunchActivity.java
@@ -34,6 +34,7 @@ import nu.yona.app.YonaApplication;
 import nu.yona.app.analytics.AnalyticsConstant;
 import nu.yona.app.analytics.YonaAnalytics;
 import nu.yona.app.api.manager.APIManager;
+import nu.yona.app.api.model.ErrorMessage;
 import nu.yona.app.enums.EncryptionMethod;
 import nu.yona.app.listener.DataLoadListenerImpl;
 import nu.yona.app.ui.login.LoginActivity;
@@ -42,6 +43,7 @@ import nu.yona.app.ui.signup.OTPActivity;
 import nu.yona.app.ui.signup.SignupActivity;
 import nu.yona.app.ui.tour.YonaCarrouselActivity;
 import nu.yona.app.utils.AppConstant;
+import nu.yona.app.utils.AppUtils;
 import nu.yona.app.utils.PreferenceConstant;
 
 import static nu.yona.app.utils.PreferenceConstant.YONA_ENCRYPTION_METHOD;
@@ -58,9 +60,8 @@ public class LaunchActivity extends BaseActivity
 		initializeCrashlytics();
 		validateYonaPasswordEncryption();
 		setUpApplicationInitialView();
-		navigateToValidActivity();
 		setListeners();
-		YonaAnalytics.trackCategoryScreen(AnalyticsConstant.LAUNCH_ACTIVITY, AnalyticsConstant.LAUNCH_ACTIVITY);
+		navigateToValidActivity();
 	}
 
 	private void initializeCrashlytics()
@@ -117,39 +118,85 @@ public class LaunchActivity extends BaseActivity
 		}
 		else if (!TextUtils.isEmpty(sharedUserPreferences.getString(PreferenceConstant.YONA_PASSCODE, "")))
 		{
-			startNewActivity(bundle, YonaActivity.class);
+			checkForValidStoredUser();
 		}
+	}
+
+
+	private void checkForValidStoredUser()
+	{
+		try
+		{
+			URL environmentURL = new URL(YonaApplication.getEventChangeManager().getDataState().getServerUrl());
+			URL storeUserURL = new URL(YonaApplication.getEventChangeManager().getDataState().getUser().getLinks().getSelf().getHref());
+			if (environmentURL.getProtocol() == storeUserURL.getProtocol())
+			{
+				moveToYonaActivity();
+			}
+			reloadUserFromServer(storeUserURL.toString().replace(storeUserURL.getProtocol(), environmentURL.getProtocol()));
+		}
+		catch (MalformedURLException e)
+		{
+			AppUtils.reportException(this.getClass().getName(), e, Thread.currentThread());
+		}
+	}
+
+	private void reloadUserFromServer(String url)
+	{
+		if (!AppUtils.isNetworkAvailable(YonaApplication.getAppContext()))
+		{
+			AppUtils.displayErrorAlert(this, new ErrorMessage(this.getString(R.string.mandatory_user_fetch_failure)));
+			return;
+		}
+		getUserFromServer(url);
+	}
+
+	private void moveToYonaActivity()
+	{
+		startNewActivity(bundle, YonaActivity.class);
+		YonaAnalytics.trackCategoryScreen(AnalyticsConstant.LAUNCH_ACTIVITY, AnalyticsConstant.LAUNCH_ACTIVITY);
+	}
+
+	private void getUserFromServer(String url)
+	{
+		showLoadingView(true, "");
+		DataLoadListenerImpl dataLoadListenerImpl = new DataLoadListenerImpl((result) -> handleUserFetchSuccess(result), (result) -> handleUserFetchFailure(result), null);
+		APIManager.getInstance().getAuthenticateManager().getUserFromServer(url, dataLoadListenerImpl);
+	}
+
+	private Object handleUserFetchSuccess(Object result)
+	{
+		moveToYonaActivity();
+		showLoadingView(false, "");
+		return null;// Dummy return value, to allow use as data load handler
+	}
+
+	private Object handleUserFetchFailure(Object error)
+	{
+		showLoadingView(false, "");
+		if (error instanceof ErrorMessage)
+		{
+			AppUtils.displayErrorAlert(this, (ErrorMessage) error);
+		}
+		else
+		{
+			AppUtils.displayErrorAlert(this, new ErrorMessage((String) error));
+		}
+		return null;// Dummy return value, to allow use as data load handler
 	}
 
 
 	private void setListeners()
 	{
-		findViewById(R.id.join).setOnClickListener(new View.OnClickListener()
+		findViewById(R.id.join).setOnClickListener(result -> startNewActivity(bundle, SignupActivity.class));
+		findViewById(R.id.login).setOnClickListener(result -> startNewActivity(LoginActivity.class));
+		findViewById(R.id.environmentSwitch).setOnLongClickListener(result ->
 		{
-			@Override
-			public void onClick(View v)
-			{
-				startNewActivity(bundle, SignupActivity.class);
-			}
-		});
-		findViewById(R.id.login).setOnClickListener(new View.OnClickListener()
-		{
-			@Override
-			public void onClick(View v)
-			{
-				startNewActivity(LoginActivity.class);
-			}
-		});
-		findViewById(R.id.environmentSwitch).setOnLongClickListener(new View.OnLongClickListener()
-		{
-			@Override
-			public boolean onLongClick(View v)
-			{
-				switchEnvironment();
-				return true;
-			}
+			switchEnvironment();
+			return true;
 		});
 	}
+
 
 	private void validateYonaPasswordEncryption()
 	{

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -227,4 +227,5 @@
     <string name="notification_disabled_message">Omdat meldingen voor de Yona-applicatie zijn uitgeschakeld kan Yona appgebruik niet meer bijhouden. Zet in de Android instellingen meldingen weer aan voor de Yona app.</string>
     <string name="yona_service_notification_channel_name">Vaste melding</string>
     <string name="support_mail_subject">Probleem met Yona app</string>
+    <string name="mandatory_user_fetch_failure">De Yona-app heeft deze keer een netwerkverbinding nodig om te starten.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,4 +229,5 @@
     <string name="notification_disabled_message">Yona cannot monitor app activity because notifications for the Yona application have been disabled. Enable notifications for Yona again in the device settings.</string>
     <string name="yona_service_notification_channel_name">Persistent notifications</string>
     <string name="support_mail_subject">Problem with Yona app</string>
+    <string name="mandatory_user_fetch_failure">The Yona app this time needs network connectivity to start</string>
 </resources>


### PR DESCRIPTION
Cause : App user is logged into to https+domain and stored user object has http+domain. Which cause goals self links mismatch and runtime crash. 
Fix:
-- App compares stored user self link with environment base url logged in. If url schemes are different then app defaults the user with environment scheme. 
-- Reloads the user data with corrected url and stores locally.