### PR TITLE
APPDEV-1263 Use regular log tags

### DIFF
--- a/app/src/main/java/nu/yona/app/YonaApplication.java
+++ b/app/src/main/java/nu/yona/app/YonaApplication.java
@@ -126,14 +126,14 @@ public class YonaApplication extends Application
 
 	private void swapUserAndAppSharedPreferences()
 	{
-		nu.yona.app.utils.Logger.logi("Preferences", "Correcting user and app preferences by swapping them");
+		nu.yona.app.utils.Logger.logi(YonaApplication.class, "Correcting user and app preferences by swapping them");
 		SharedPreferences tempSharedUserPrefs = YonaApplication.getAppContext().getSharedPreferences("TEMP_USER_PREF", Context.MODE_PRIVATE);
 		SharedPreferences tempSharedAppPrefs = YonaApplication.getAppContext().getSharedPreferences("TEMP_APP_PREF", Context.MODE_PRIVATE);
 		AppUtils.moveSharedPreferences(sharedAppPreferences, tempSharedUserPrefs);
 		AppUtils.moveSharedPreferences(sharedUserPreferences, tempSharedAppPrefs);
 		AppUtils.moveSharedPreferences(tempSharedAppPrefs, sharedAppPreferences);
 		AppUtils.moveSharedPreferences(tempSharedUserPrefs, sharedUserPreferences);
-		nu.yona.app.utils.Logger.logi("Preferences", "Corrected user and app preferences by swapping them");
+		nu.yona.app.utils.Logger.logi(YonaApplication.class, "Corrected user and app preferences by swapping them");
 	}
 
 	private void enableStickMode()
@@ -182,7 +182,7 @@ public class YonaApplication extends Application
 			}
 			catch (PackageManager.NameNotFoundException e)
 			{
-				AppUtils.reportException(YonaApplication.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(YonaApplication.class, e, Thread.currentThread());
 			}
 
 			GoogleAnalytics.getInstance(mContext).getLogger()

--- a/app/src/main/java/nu/yona/app/analytics/YonaAnalytics.java
+++ b/app/src/main/java/nu/yona/app/analytics/YonaAnalytics.java
@@ -31,7 +31,6 @@ public class YonaAnalytics
 {
 	private static YonaAnalytics instance;
 	private Categorizable category = null;
-	private static final String TAG = "YonaAnalytics";
 
 	public static YonaAnalytics getInstance()
 	{
@@ -71,7 +70,7 @@ public class YonaAnalytics
 		{
 			return;
 		}
-		logi(TAG, "Analytics: Category: [" + category + "] Label: [" + label + "] Action: [" + action + "]");
+		logi(YonaAnalytics.class, "Analytics: Category: [" + category + "] Label: [" + label + "] Action: [" + action + "]");
 		//commented out until things are probably working
 		Tracker t = YonaApplication.getTracker();
 		if (getAppUser() != null
@@ -100,7 +99,7 @@ public class YonaAnalytics
 	{
 		if (category == null)
 		{
-			loge(TAG, "Attempt to fire analytics event prior to initializing current Categorizable");
+			loge(YonaAnalytics.class, "Attempt to fire analytics event prior to initializing current Categorizable");
 			return "null";
 		}
 		return category.getAnalyticsCategory();

--- a/app/src/main/java/nu/yona/app/api/db/DatabaseHelper.java
+++ b/app/src/main/java/nu/yona/app/api/db/DatabaseHelper.java
@@ -30,7 +30,7 @@ public class DatabaseHelper extends SQLiteOpenHelper
 		super(context, DBConstant.DATABASE_NAME, null, DBConstant.DATABASE_VERSION);
 		synchronized (this)
 		{
-			Logger.logi(DatabaseHelper.class.getName(), "DatabaseHelper constructor called");
+			Logger.logi(DatabaseHelper.class, "DatabaseHelper constructor called");
 			this.getWritableDatabase();
 		}
 	}
@@ -74,7 +74,7 @@ public class DatabaseHelper extends SQLiteOpenHelper
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DatabaseHelper.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(DatabaseHelper.class, e, Thread.currentThread());
 		}
 	}
 
@@ -85,7 +85,7 @@ public class DatabaseHelper extends SQLiteOpenHelper
 	{
 		try
 		{
-			Logger.loge(DatabaseHelper.class.getSimpleName(), "Delete all data");
+			Logger.loge(DatabaseHelper.class, "Delete all data");
 			mInstance.getWritableDatabase().execSQL("DROP TABLE IF EXISTS " + DBConstant.TBL_USER_DATA);
 			mInstance.getWritableDatabase().execSQL("DROP TABLE IF EXISTS " + DBConstant.TBL_ACTIVITY_CATEGORIES);
 			mInstance.getWritableDatabase().execSQL("DROP TABLE IF EXISTS " + DBConstant.TBL_GOAL);
@@ -94,7 +94,7 @@ public class DatabaseHelper extends SQLiteOpenHelper
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DatabaseHelper.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(DatabaseHelper.class, e, Thread.currentThread());
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/api/db/JsonSerializer.java
+++ b/app/src/main/java/nu/yona/app/api/db/JsonSerializer.java
@@ -44,7 +44,7 @@ public class JsonSerializer implements DbSerializer
 		}
 		catch (IOException e)
 		{
-			AppUtils.reportException(JsonSerializer.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(JsonSerializer.class, e, Thread.currentThread());
 		}
 		return new byte[0];
 	}

--- a/app/src/main/java/nu/yona/app/api/manager/dao/ActivityCategoriesDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/ActivityCategoriesDAO.java
@@ -64,7 +64,7 @@ public class ActivityCategoriesDAO extends BaseDAO
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityCategories.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(ActivityCategories.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -89,7 +89,7 @@ public class ActivityCategoriesDAO extends BaseDAO
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityCategories.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityCategories.class, e, Thread.currentThread());
 		}
 		finally
 		{

--- a/app/src/main/java/nu/yona/app/api/manager/dao/ActivityTrackerDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/ActivityTrackerDAO.java
@@ -80,7 +80,7 @@ public class ActivityTrackerDAO extends BaseDAO
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(GoalDAO.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(GoalDAO.class, e, Thread.currentThread());
 		}
 		finally
 		{

--- a/app/src/main/java/nu/yona/app/api/manager/dao/AuthenticateDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/AuthenticateDAO.java
@@ -57,7 +57,7 @@ public class AuthenticateDAO extends BaseDAO
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateDAO.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateDAO.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -114,7 +114,7 @@ public class AuthenticateDAO extends BaseDAO
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityCategories.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityCategories.class, e, Thread.currentThread());
 		}
 		finally
 		{

--- a/app/src/main/java/nu/yona/app/api/manager/dao/BaseDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/BaseDAO.java
@@ -135,7 +135,7 @@ class BaseDAO
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(BaseDAO.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(BaseDAO.class, e, Thread.currentThread());
 		}
 	}
 }

--- a/app/src/main/java/nu/yona/app/api/manager/dao/GoalDAO.java
+++ b/app/src/main/java/nu/yona/app/api/manager/dao/GoalDAO.java
@@ -64,7 +64,7 @@ public class GoalDAO extends BaseDAO
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(GoalDAO.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(GoalDAO.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -89,7 +89,7 @@ public class GoalDAO extends BaseDAO
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(GoalDAO.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(GoalDAO.class, e, Thread.currentThread());
 		}
 		finally
 		{

--- a/app/src/main/java/nu/yona/app/api/manager/impl/ActivityCategoryManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/ActivityCategoryManagerImpl.java
@@ -83,7 +83,7 @@ public class ActivityCategoryManagerImpl implements ActivityCategoryManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityCategoryManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(ActivityCategoryManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 		return null; // No value to return from here
 	}
@@ -104,7 +104,7 @@ public class ActivityCategoryManagerImpl implements ActivityCategoryManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityCategoryManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(ActivityCategoryManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 }

--- a/app/src/main/java/nu/yona/app/api/manager/impl/ActivityManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/ActivityManagerImpl.java
@@ -132,7 +132,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -271,7 +271,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (NullPointerException e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread());
 		}
 		return null; // Dummy return value, to allow use as data load handler
 	}
@@ -304,7 +304,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread());
 		}
 	}
 
@@ -312,7 +312,7 @@ public class ActivityManagerImpl implements ActivityManager
 
 	private void postActivityOnServer(AppActivity activity, boolean fromDB)
 	{
-		Logger.logi("postActivityOnServer", "isSyncAPICallDone: " + isSyncAPICallDone);
+		Logger.logi(ActivityManagerImpl.class, "isSyncAPICallDone: " + isSyncAPICallDone);
 		User user = getSharedAppDataState().getUser();
 		if (!isSyncAPICallDone)
 		{
@@ -696,7 +696,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -709,7 +709,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -800,7 +800,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (ParseException e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread());
 		}
 		activity.setDate(overview.getDate());
 		activity = getWeekDayActivity(activity);
@@ -847,7 +847,7 @@ public class ActivityManagerImpl implements ActivityManager
 			}
 			catch (ParseException e)
 			{
-				AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread());
 			}
 			weekActivity.setDate(weekActivity.getDate());
 			weekActivity = getWeekDayActivity(weekActivity);
@@ -1059,7 +1059,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (ParseException e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread());
 		}
 		// TODO: History check need to ve verify. Concern Issue: http://jira.yona.nu/browse/APPDEV-999.
 		if (activity.getYonaGoal() != null && activity.getYonaGoal() != null/* && !activity.getYonaGoal().isHistoryItem()*/)
@@ -1309,7 +1309,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -1339,7 +1339,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (ParseException e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread());
 		}
 		return null;
 	}
@@ -1454,7 +1454,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (ParseException e)
 		{
-			AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(NotificationManagerImpl.class, e, Thread.currentThread());
 		}
 		listener.onDataLoad(generateTimeZoneSpread(activity));
 		return null; // Dummy return value, to allow use as data load handler
@@ -1485,7 +1485,7 @@ public class ActivityManagerImpl implements ActivityManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread());
 		}
 		return null; // Dummy return value, to allow use as data load handler
 	}
@@ -1510,7 +1510,7 @@ public class ActivityManagerImpl implements ActivityManager
 			}
 			catch (Exception e)
 			{
-				AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread());
 			}
 		}
 	}

--- a/app/src/main/java/nu/yona/app/api/manager/impl/AuthenticateManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/AuthenticateManagerImpl.java
@@ -133,7 +133,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -308,7 +308,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -349,7 +349,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -445,7 +445,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -497,7 +497,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -529,7 +529,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -579,7 +579,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 
 	}
@@ -626,7 +626,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -667,7 +667,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -740,7 +740,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -801,7 +801,7 @@ public class AuthenticateManagerImpl implements AuthenticateManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/api/manager/impl/BuddyManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/BuddyManagerImpl.java
@@ -126,7 +126,7 @@ public class BuddyManagerImpl implements BuddyManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(BuddyManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(BuddyManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -174,7 +174,7 @@ public class BuddyManagerImpl implements BuddyManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(BuddyManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(BuddyManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -239,7 +239,7 @@ public class BuddyManagerImpl implements BuddyManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(BuddyManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(BuddyManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 }

--- a/app/src/main/java/nu/yona/app/api/manager/impl/ChallengesManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/ChallengesManagerImpl.java
@@ -207,7 +207,7 @@ public class ChallengesManagerImpl implements ChallengesManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityCategoryManagerImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityCategoryManagerImpl.class, e, Thread.currentThread());
 		}
 		return false;
 	}

--- a/app/src/main/java/nu/yona/app/api/manager/impl/DeviceManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/DeviceManagerImpl.java
@@ -147,7 +147,7 @@ public class DeviceManagerImpl implements DeviceManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -191,7 +191,7 @@ public class DeviceManagerImpl implements DeviceManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -235,7 +235,7 @@ public class DeviceManagerImpl implements DeviceManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -275,7 +275,7 @@ public class DeviceManagerImpl implements DeviceManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 
 	}

--- a/app/src/main/java/nu/yona/app/api/manager/impl/GoalManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/GoalManagerImpl.java
@@ -85,7 +85,7 @@ public class GoalManagerImpl implements GoalManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -122,7 +122,7 @@ public class GoalManagerImpl implements GoalManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -159,7 +159,7 @@ public class GoalManagerImpl implements GoalManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -196,7 +196,7 @@ public class GoalManagerImpl implements GoalManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -229,7 +229,7 @@ public class GoalManagerImpl implements GoalManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -262,7 +262,7 @@ public class GoalManagerImpl implements GoalManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(DeviceManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/api/manager/impl/NotificationManagerImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/impl/NotificationManagerImpl.java
@@ -93,7 +93,7 @@ public class NotificationManagerImpl implements NotificationManager
 		}
 		catch (IllegalArgumentException e)
 		{
-			AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -140,9 +140,9 @@ public class NotificationManagerImpl implements NotificationManager
 			String uploadDate = DateUtility.getRelativeDate(futureCalendar);
 			return uploadDate;
 		}
-		catch (ParseException parseEx)
+		catch (ParseException e)
 		{
-			AppUtils.reportException(ActivityManagerImpl.class.getSimpleName(), parseEx, Thread.currentThread());
+			AppUtils.reportException(ActivityManagerImpl.class, e, Thread.currentThread());
 		}
 		return null;
 	}
@@ -205,7 +205,7 @@ public class NotificationManagerImpl implements NotificationManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -246,7 +246,7 @@ public class NotificationManagerImpl implements NotificationManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -272,7 +272,7 @@ public class NotificationManagerImpl implements NotificationManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -313,7 +313,7 @@ public class NotificationManagerImpl implements NotificationManager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(NotificationManagerImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationManagerImpl.class, e, Thread.currentThread(), listener);
 		}
 		finally
 		{

--- a/app/src/main/java/nu/yona/app/api/manager/network/ActivityNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/ActivityNetworkImpl.java
@@ -44,7 +44,7 @@ public class ActivityNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -63,7 +63,7 @@ public class ActivityNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -82,7 +82,7 @@ public class ActivityNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -101,7 +101,7 @@ public class ActivityNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -122,7 +122,7 @@ public class ActivityNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -142,7 +142,7 @@ public class ActivityNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -154,7 +154,7 @@ public class ActivityNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -186,7 +186,7 @@ public class ActivityNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -218,7 +218,7 @@ public class ActivityNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/api/manager/network/AuthenticateNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/AuthenticateNetworkImpl.java
@@ -57,7 +57,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -69,7 +69,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -109,7 +109,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -129,7 +129,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -148,7 +148,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -168,7 +168,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -187,7 +187,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -205,7 +205,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -224,7 +224,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -263,7 +263,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -282,7 +282,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -312,7 +312,7 @@ public class AuthenticateNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AuthenticateNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(AuthenticateNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/api/manager/network/BuddyNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/BuddyNetworkImpl.java
@@ -61,7 +61,7 @@ public class BuddyNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(BuddyNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(BuddyNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -100,7 +100,7 @@ public class BuddyNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(BuddyNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(BuddyNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -119,7 +119,7 @@ public class BuddyNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(BuddyNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(BuddyNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 }

--- a/app/src/main/java/nu/yona/app/api/manager/network/DeviceNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/DeviceNetworkImpl.java
@@ -40,7 +40,7 @@ public class DeviceNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(DeviceNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 
@@ -59,7 +59,7 @@ public class DeviceNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(DeviceNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 
@@ -98,7 +98,7 @@ public class DeviceNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DeviceNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(DeviceNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 }

--- a/app/src/main/java/nu/yona/app/api/manager/network/GoalNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/GoalNetworkImpl.java
@@ -40,7 +40,7 @@ public class GoalNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(GoalNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 
@@ -60,7 +60,7 @@ public class GoalNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(GoalNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 
@@ -80,7 +80,7 @@ public class GoalNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(GoalNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 
@@ -99,7 +99,7 @@ public class GoalNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(GoalNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 
@@ -119,7 +119,7 @@ public class GoalNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(GoalNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 
@@ -139,7 +139,7 @@ public class GoalNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(GoalNetworkImpl.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(GoalNetworkImpl.class, e, Thread.currentThread());
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/api/manager/network/NotificationNetworkImpl.java
+++ b/app/src/main/java/nu/yona/app/api/manager/network/NotificationNetworkImpl.java
@@ -60,7 +60,7 @@ public class NotificationNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -100,7 +100,7 @@ public class NotificationNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -119,7 +119,7 @@ public class NotificationNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -139,7 +139,7 @@ public class NotificationNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 
@@ -151,7 +151,7 @@ public class NotificationNetworkImpl extends BaseImpl
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(NotificationNetworkImpl.class.getSimpleName(), e, Thread.currentThread(), listener);
+			AppUtils.reportException(NotificationNetworkImpl.class, e, Thread.currentThread(), listener);
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
+++ b/app/src/main/java/nu/yona/app/api/receiver/YonaReceiver.java
@@ -74,7 +74,7 @@ public class YonaReceiver extends BroadcastReceiver
 	@TargetApi(Build.VERSION_CODES.O)
 	private void handleDeviceDozeMode(Context context)
 	{
-		Logger.loge("Broadcast", "ACTION_DEVICE_IDLE_MODE_CHANGED");
+		Logger.loge(YonaReceiver.class, "ACTION_DEVICE_IDLE_MODE_CHANGED");
 		PowerManager powerManager = (PowerManager) context.getSystemService(POWER_SERVICE);
 		if (powerManager.isDeviceIdleMode() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
 		{
@@ -84,20 +84,20 @@ public class YonaReceiver extends BroadcastReceiver
 
 	private void handleRebootCompletedBroadcast(Context context)
 	{
-		Logger.loge("Broadcast", "ACTION_BOOT_COMPLETED");
+		Logger.loge(YonaReceiver.class, "ACTION_BOOT_COMPLETED");
 		startService(context);
 	}
 
 	private void handleScreenOnBroadcast(Context context)
 	{
-		Logger.logi("Broadcast", "ACTION_SCREEN_ON");
+		Logger.logi(YonaReceiver.class, "ACTION_SCREEN_ON");
 		startService(context);
 		AppUtils.startVPN(context, false);
 	}
 
 	private void handleScreenOffBroadcast(Context context)
 	{
-		Logger.logi("Broadcast", "ACTION_SCREEN_OFF");
+		Logger.logi(YonaReceiver.class, "ACTION_SCREEN_OFF");
 		AppUtils.setNullScheduler();
 		AppUtils.sendLogToServer(AppConstant.ONE_SECOND);
 	}
@@ -105,7 +105,7 @@ public class YonaReceiver extends BroadcastReceiver
 	@TargetApi(Build.VERSION_CODES.O)
 	private void handleWakeUpAlarm(Context context)
 	{
-		Logger.logi("Broadcast", "WAKE_UP");
+		Logger.logi(YonaReceiver.class, "WAKE_UP");
 		// Device is awake from doze/sleep (it can be because of user interaction or of some silent Push notifications).
 		// We should start service only when device is interactive else schedule next alarm
 		if (isDeviceInteractive(context))
@@ -140,7 +140,7 @@ public class YonaReceiver extends BroadcastReceiver
 
 	private void handleRestartVPNBroadcast(Context context)
 	{
-		Logger.logi("Broadcast", "Restart VPN Broadcast received");
+		Logger.logi(YonaReceiver.class, "Restart VPN Broadcast received");
 		showRestartVPN(context.getString(R.string.vpn_disconnected));
 	}
 

--- a/app/src/main/java/nu/yona/app/api/service/ActivityMonitorService.java
+++ b/app/src/main/java/nu/yona/app/api/service/ActivityMonitorService.java
@@ -89,7 +89,7 @@ public class ActivityMonitorService extends Service
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityMonitorService.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityMonitorService.class, e, Thread.currentThread());
 		}
 		return currentApp;
 	}
@@ -219,7 +219,7 @@ public class ActivityMonitorService extends Service
 
 	private void updateOnServer(String pkgname)
 	{
-		Logger.logi("updateOnServer", "pck: " + pkgname);
+		Logger.logi(ActivityMonitorService.class, "pck: " + pkgname);
 		if (previousAppName != null && !pkgname.equals("NULL") && startTime != null && endTime != null && startTime.before(endTime))
 		{
 			APIManager.getInstance().getActivityManager().postActivityToDB(previousAppName, startTime, endTime);
@@ -252,7 +252,7 @@ public class ActivityMonitorService extends Service
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(ActivityMonitorService.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(ActivityMonitorService.class, e, Thread.currentThread());
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/customview/CustomProgressDialog.java
+++ b/app/src/main/java/nu/yona/app/customview/CustomProgressDialog.java
@@ -103,7 +103,7 @@ public class CustomProgressDialog extends Dialog
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(CustomProgressDialog.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(CustomProgressDialog.class, e, Thread.currentThread());
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/customview/YonaFontUtils.java
+++ b/app/src/main/java/nu/yona/app/customview/YonaFontUtils.java
@@ -92,7 +92,7 @@ class YonaFontUtils
 			}
 			catch (Exception e)
 			{
-				AppUtils.reportException(YonaFontUtils.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(YonaFontUtils.class, e, Thread.currentThread());
 				return null;
 			}
 

--- a/app/src/main/java/nu/yona/app/security/MyCipher.java
+++ b/app/src/main/java/nu/yona/app/security/MyCipher.java
@@ -76,7 +76,7 @@ public class MyCipher
 		catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | UnsupportedEncodingException
 				| IllegalBlockSizeException | BadPaddingException | InvalidParameterSpecException | InvalidKeySpecException e)
 		{
-			AppUtils.reportException(MyCipher.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(MyCipher.class, e, Thread.currentThread());
 		}
 		return null;
 	}
@@ -93,7 +93,7 @@ public class MyCipher
 		catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException
 				| IllegalBlockSizeException | BadPaddingException | InvalidKeySpecException e)
 		{
-			AppUtils.reportException(MyCipher.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(MyCipher.class, e, Thread.currentThread());
 		}
 		return null;
 	}
@@ -191,7 +191,7 @@ public class MyCipher
 		catch (UnsupportedEncodingException | InvalidAlgorithmParameterException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException
 				| IllegalBlockSizeException | BadPaddingException e)
 		{
-			AppUtils.reportException(MyCipher.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(MyCipher.class, e, Thread.currentThread());
 		}
 		return null;
 	}

--- a/app/src/main/java/nu/yona/app/security/PRNGFixes.java
+++ b/app/src/main/java/nu/yona/app/security/PRNGFixes.java
@@ -320,7 +320,7 @@ public final class PRNGFixes
 			{
 				// On a small fraction of devices /dev/urandom is not writable.
 				// Log and ignore.
-				AppUtils.reportException(PRNGFixes.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(PRNGFixes.class, e, Thread.currentThread());
 			}
 			finally
 			{

--- a/app/src/main/java/nu/yona/app/ui/LaunchActivity.java
+++ b/app/src/main/java/nu/yona/app/ui/LaunchActivity.java
@@ -145,7 +145,7 @@ public class LaunchActivity extends BaseActivity
 		}
 		catch (MalformedURLException e)
 		{
-			AppUtils.reportException(this.getClass().getName(), e, Thread.currentThread());
+			AppUtils.reportException(LaunchActivity.class, e, Thread.currentThread());
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/ui/YonaActivity.java
+++ b/app/src/main/java/nu/yona/app/ui/YonaActivity.java
@@ -353,7 +353,7 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
 		{
 			return;
 		}
-		Logger.loge("Notifications Disabled", this.getString(R.string.notification_disabled_message));
+		Logger.loge(YonaActivity.class, this.getString(R.string.notification_disabled_message));
 		AppUtils.displayErrorAlert(getActivity(), new ErrorMessage(this.getString(R.string.notification_disabled_message)));
 	}
 
@@ -434,7 +434,7 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(YonaActivity.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(YonaActivity.class, e, Thread.currentThread());
 		}
 	}
 
@@ -599,9 +599,9 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
 			FileOutputStream fos = new FileOutputStream(file);
 			imageBitmap.compress(Bitmap.CompressFormat.JPEG, 100, fos);
 		}
-		catch (FileNotFoundException ex)
+		catch (FileNotFoundException e)
 		{
-			AppUtils.reportException(YonaActivity.class.getSimpleName(), ex, Thread.currentThread());
+			AppUtils.reportException(YonaActivity.class, e, Thread.currentThread());
 			return null;
 		}
 		return file;
@@ -1147,7 +1147,7 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(YonaActivity.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(YonaActivity.class, e, Thread.currentThread());
 		}
 	}
 
@@ -1281,7 +1281,7 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
 				}
 				catch (Exception e)
 				{
-					AppUtils.reportException(YonaActivity.class.getSimpleName(), e, Thread.currentThread());
+					AppUtils.reportException(YonaActivity.class, e, Thread.currentThread());
 				}
 				return null;
 			}
@@ -1407,7 +1407,7 @@ public class YonaActivity extends BaseActivity implements FragmentManager.OnBack
 										   @NonNull String permissions[],
 										   @NonNull int[] grantResults)
 	{
-		Logger.loge(YonaActivity.class.getSimpleName(), "onRequestPermissionsResult");
+		Logger.loge(YonaActivity.class, "onRequestPermissionsResult");
 		isToDisplayLogin = false;
 		// Make sure it's our original READ_CONTACTS request
 		if (requestCode == READ_EXTERNAL_STORAGE_REQUEST)

--- a/app/src/main/java/nu/yona/app/ui/challenges/ChallengesGoalDetailFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/challenges/ChallengesGoalDetailFragment.java
@@ -67,7 +67,6 @@ public class ChallengesGoalDetailFragment extends BaseFragment implements View.O
 	private TimeZoneGoalsAdapter timeZoneGoalsAdapter;
 	private View btnChallengesContainer;
 
-	private static final String TAG = "ChallengesGoalDetailFragment";
 	/**
 	 * Use this listener only for Time zone picker
 	 */
@@ -585,7 +584,7 @@ public class ChallengesGoalDetailFragment extends BaseFragment implements View.O
 			@Override
 			public void onCancel(DialogInterface dialogInterface)
 			{
-				logd(TAG, "TimePicker Dialog was cancelled");
+				logd(ChallengesGoalDetailFragment.class, "TimePicker Dialog was cancelled");
 			}
 		});
 		mTimePickerDialog.show(getActivity().getFragmentManager(), "Timepickerdialog");
@@ -779,7 +778,7 @@ public class ChallengesGoalDetailFragment extends BaseFragment implements View.O
 	@Override
 	public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser)
 	{
-		logi(TAG, "progress...." + progress);
+		logi(ChallengesGoalDetailFragment.class, "progress...." + progress);
 		mBudgetGoalTime.setText("" + progress);
 		updateTimeZoneUI();
 	}

--- a/app/src/main/java/nu/yona/app/ui/comment/CommentsAdapter.java
+++ b/app/src/main/java/nu/yona/app/ui/comment/CommentsAdapter.java
@@ -96,7 +96,7 @@ public class CommentsAdapter extends RecyclerView.Adapter<CommentHolder>
 					}
 					catch (Exception e)
 					{
-						AppUtils.reportException(CommentsAdapter.class.getSimpleName(), e, Thread.currentThread());
+						AppUtils.reportException(CommentsAdapter.class, e, Thread.currentThread());
 						holder.getProfileImageTxt().setBackground(ContextCompat.getDrawable(mContext, R.drawable.bg_small_friend_round));
 					}
 
@@ -138,7 +138,7 @@ public class CommentsAdapter extends RecyclerView.Adapter<CommentHolder>
 					}
 					catch (Exception e)
 					{
-						AppUtils.reportException(CommentsAdapter.class.getSimpleName(), e, Thread.currentThread());
+						AppUtils.reportException(CommentsAdapter.class, e, Thread.currentThread());
 						holder.getProfileImageTxt().setBackground(ContextCompat.getDrawable(mContext, R.drawable.bg_small_friend_round));
 					}
 				}

--- a/app/src/main/java/nu/yona/app/ui/dashboard/PerDayFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/dashboard/PerDayFragment.java
@@ -80,7 +80,7 @@ public class PerDayFragment extends BaseFragment
 			}
 			catch (Exception e)
 			{
-				AppUtils.reportException(PerDayFragment.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(PerDayFragment.class, e, Thread.currentThread());
 			}
 		}
 	};

--- a/app/src/main/java/nu/yona/app/ui/dashboard/PerWeekFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/dashboard/PerWeekFragment.java
@@ -80,7 +80,7 @@ public class PerWeekFragment extends BaseFragment
 			}
 			catch (Exception e)
 			{
-				AppUtils.reportException(PerWeekFragment.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(PerWeekFragment.class, e, Thread.currentThread());
 			}
 		}
 	};

--- a/app/src/main/java/nu/yona/app/ui/dashboard/WeekActivityDetailFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/dashboard/WeekActivityDetailFragment.java
@@ -330,7 +330,7 @@ public class WeekActivityDetailFragment extends BaseFragment implements EventCha
 		}
 		catch (NullPointerException e)
 		{
-			AppUtils.reportException(WeekActivityDetailFragment.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(WeekActivityDetailFragment.class, e, Thread.currentThread());
 		}
 		return null; // Dummy return value, to allow use as data load handler
 	}

--- a/app/src/main/java/nu/yona/app/ui/friends/AddFriendManuallyFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/friends/AddFriendManuallyFragment.java
@@ -297,7 +297,7 @@ public class AddFriendManuallyFragment extends BaseFragment implements EventChan
 		YonaAnalytics.createTapEventWithCategory(AnalyticsConstant.ADD_FRIEND, getString(R.string.invitefriend));
 		String formattedMobileNumber = MobileNumberFormatter.format(mobileNumber.getText().toString());
 		mobileNumber.setText(formattedMobileNumber);
-		Logger.logi("Mobile_validation", formattedMobileNumber);
+		Logger.logi(AddFriendManuallyFragment.class, formattedMobileNumber);
 		makeAddFriendAPIRequest(firstName.getText().toString(), lastName.getText().toString(), email.getText().toString(), formattedMobileNumber);
 	}
 

--- a/app/src/main/java/nu/yona/app/ui/friends/TimelineFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/friends/TimelineFragment.java
@@ -78,7 +78,7 @@ public class TimelineFragment extends BaseFragment implements EventChangeListene
 			}
 			catch (Exception e)
 			{
-				AppUtils.reportException(TimelineFragment.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(TimelineFragment.class, e, Thread.currentThread());
 			}
 		}
 	};

--- a/app/src/main/java/nu/yona/app/ui/message/NotificationFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/message/NotificationFragment.java
@@ -275,7 +275,7 @@ public class NotificationFragment extends BaseFragment
 		}
 		catch (ParseException e)
 		{
-			AppUtils.reportException(NotificationFragment.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(NotificationFragment.class, e, Thread.currentThread());
 		}
 		return messageIntent;
 	}
@@ -445,7 +445,7 @@ public class NotificationFragment extends BaseFragment
 		}
 		catch (IllegalArgumentException e)
 		{
-			AppUtils.reportException(NotificationFragment.class.getSimpleName(), e, Thread.currentThread(), null);
+			AppUtils.reportException(NotificationFragment.class, e, Thread.currentThread(), null);
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/settings/SettingsFragment.java
@@ -337,7 +337,7 @@ public class SettingsFragment extends BaseFragment
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(SettingsFragment.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(SettingsFragment.class, e, Thread.currentThread());
 		}
 	}
 
@@ -362,7 +362,7 @@ public class SettingsFragment extends BaseFragment
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(SettingsFragment.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(SettingsFragment.class, e, Thread.currentThread());
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/ui/signup/StepTwoFragment.java
+++ b/app/src/main/java/nu/yona/app/ui/signup/StepTwoFragment.java
@@ -122,7 +122,7 @@ public class StepTwoFragment extends BaseFragment implements EventChangeListener
 			}
 			catch (NumberParseException e)
 			{
-				AppUtils.reportException(StepTwoFragment.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(StepTwoFragment.class, e, Thread.currentThread());
 			}
 		}
 		else

--- a/app/src/main/java/nu/yona/app/ui/tour/CarrouselViewPager.java
+++ b/app/src/main/java/nu/yona/app/ui/tour/CarrouselViewPager.java
@@ -70,7 +70,7 @@ public class CarrouselViewPager extends ViewPager
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(CarrouselViewPager.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(CarrouselViewPager.class, e, Thread.currentThread());
 		}
 	}
 

--- a/app/src/main/java/nu/yona/app/utils/AppUtils.java
+++ b/app/src/main/java/nu/yona/app/utils/AppUtils.java
@@ -67,9 +67,9 @@ import nu.yona.app.listener.DataLoadListenerImpl;
 import nu.yona.app.state.EventChangeManager;
 import nu.yona.timepicker.time.Timepoint;
 
+import static nu.yona.app.YonaApplication.getAppUser;
 import static nu.yona.app.YonaApplication.getSharedAppPreferences;
 import static nu.yona.app.YonaApplication.getSharedUserPreferences;
-import static nu.yona.app.YonaApplication.getAppUser;
 import static nu.yona.app.utils.Logger.loge;
 import static nu.yona.app.utils.Logger.logi;
 
@@ -86,8 +86,6 @@ public class AppUtils
 	private static int certificateDownloadAttempts = 0;
 	private static int vpnConnectionAttempts = 0;
 	private static final Handler uiTaskHandler = new Handler();
-
-	private static final String TAG = "AppUtils";
 
 	/**
 	 * Has permission boolean.
@@ -135,7 +133,7 @@ public class AppUtils
 		}
 		catch (Exception e)
 		{
-			reportException(AppUtils.class.getSimpleName(), e, Thread.currentThread());
+			reportException(AppUtils.class, e, Thread.currentThread());
 		}
 	}
 
@@ -181,7 +179,7 @@ public class AppUtils
 		}
 		catch (Exception e)
 		{
-			reportException(AppUtils.class.getSimpleName(), e, Thread.currentThread());
+			reportException(AppUtils.class, e, Thread.currentThread());
 		}
 	}
 
@@ -211,7 +209,7 @@ public class AppUtils
 	 */
 	public static void registerReceiver(Context context)
 	{
-		loge(TAG, "Register Receiver");
+		loge(AppUtils.class, "Register Receiver");
 		IntentFilter filter = new IntentFilter();
 		filter.addAction(Intent.ACTION_SCREEN_ON);
 		filter.addAction(Intent.ACTION_SCREEN_OFF);
@@ -240,7 +238,7 @@ public class AppUtils
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(AppUtils.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(AppUtils.class, e, Thread.currentThread());
 		}
 		return Pair.create(time, (long) 0);
 	}
@@ -273,7 +271,7 @@ public class AppUtils
 	 * @param t         Current Thread (Thread.currentThread())
 	 * @param listener  DataLoadListener to update UI
 	 */
-	public static void reportException(String className, Exception exception, Thread t, DataLoadListener listener)
+	public static void reportException(Class<?> originClass, Exception exception, Thread t, DataLoadListener listener)
 	{
 		ErrorMessage errorMessage = getErrorMessageFromException(exception);
 		if (listener != null)
@@ -284,7 +282,7 @@ public class AppUtils
 		{
 			showErrorToast(errorMessage);
 		}
-		Logger.loge(className, errorMessage.getMessage(), exception);
+		Logger.loge(originClass, errorMessage.getMessage(), exception);
 	}
 
 	/**
@@ -303,13 +301,13 @@ public class AppUtils
 	/**
 	 * Report exception.
 	 *
-	 * @param className class name where exception throws
-	 * @param exception Error
-	 * @param t         Current Thread (Thread.currentThread())
+	 * @param originClass class reporting the exception
+	 * @param exception   Error
+	 * @param t           Current Thread (Thread.currentThread())
 	 */
-	public static void reportException(String className, Exception exception, Thread t)
+	public static void reportException(Class<?> originClass, Exception exception, Thread t)
 	{
-		AppUtils.reportException(className, exception, t, null);
+		AppUtils.reportException(originClass, exception, t, null);
 	}
 
 
@@ -565,13 +563,13 @@ public class AppUtils
 			YonaApplication.getEventChangeManager().getSharedPreference().setRootCertPath(result.toString());
 			YonaApplication.getEventChangeManager().notifyChange(EventChangeManager.EVENT_ROOT_CERTIFICATE_DOWNLOADED, null);
 		}
-		logi(TAG, "Download successful: " + result.toString());
+		logi(AppUtils.class, "Download successful: " + result.toString());
 		return null; // Dummy return value, to allow use as data load handler
 	}
 
 	private static Object handleDownloadFileFromUrlFailure()
 	{
-		loge(TAG, "Download fail");
+		loge(AppUtils.class, "Download fail");
 		certificateDownloadAttempts++;
 		if (certificateDownloadAttempts < 3)
 		{
@@ -596,14 +594,14 @@ public class AppUtils
 		{
 			YonaApplication.getEventChangeManager().getSharedPreference().setVPNProfilePath(result.toString());
 			YonaApplication.getEventChangeManager().notifyChange(EventChangeManager.EVENT_VPN_CERTIFICATE_DOWNLOADED, null);
-			logi(TAG, "Download successful: " + result.toString());
+			logi(AppUtils.class, "Download successful: " + result.toString());
 		}
 		return null; // Dummy return value, to allow use as data load handler
 	}
 
 	private static Object handleDownloadVpnFromUrlFailure()
 	{
-		loge(TAG, "Download fail");
+		loge(AppUtils.class, "Download fail");
 		vpnConnectionAttempts++;
 		if (vpnConnectionAttempts < 3)
 		{
@@ -628,7 +626,7 @@ public class AppUtils
 			}
 			catch (java.io.IOException e)
 			{
-				AppUtils.reportException(AppUtils.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(AppUtils.class, e, Thread.currentThread());
 			}
 		}
 		return null;
@@ -667,7 +665,7 @@ public class AppUtils
 		}
 		catch (Exception e)
 		{
-			reportException(AppUtils.class.getSimpleName(), e, Thread.currentThread());
+			reportException(AppUtils.class, e, Thread.currentThread());
 		}
 		return isCertExist;
 	}

--- a/app/src/main/java/nu/yona/app/utils/DateUtility.java
+++ b/app/src/main/java/nu/yona/app/utils/DateUtility.java
@@ -79,7 +79,7 @@ public class DateUtility
 			}
 			catch (Exception e)
 			{
-				AppUtils.reportException(DateUtility.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(DateUtility.class, e, Thread.currentThread());
 			}
 		}
 
@@ -171,7 +171,7 @@ public class DateUtility
 		}
 		catch (Exception e)
 		{
-			AppUtils.reportException(DateUtility.class.getSimpleName(), e, Thread.currentThread());
+			AppUtils.reportException(DateUtility.class, e, Thread.currentThread());
 		}
 
 		return listOfdates;
@@ -240,7 +240,7 @@ public class DateUtility
 			}
 			catch (ParseException e)
 			{
-				AppUtils.reportException(DateUtility.class.getSimpleName(), e, Thread.currentThread());
+				AppUtils.reportException(DateUtility.class, e, Thread.currentThread());
 			}
 		}
 

--- a/app/src/main/java/nu/yona/app/utils/DownloadFileFromURL.java
+++ b/app/src/main/java/nu/yona/app/utils/DownloadFileFromURL.java
@@ -80,7 +80,7 @@ public class DownloadFileFromURL
 				}
 				catch (Exception e)
 				{
-					Logger.loge(DownloadFileFromURL.class.getSimpleName(), e.toString());
+					Logger.loge(DownloadFileFromURL.class, e.toString());
 				}
 				finally
 
@@ -99,7 +99,7 @@ public class DownloadFileFromURL
 					}
 					catch (Exception e)
 					{
-						Logger.loge(DownloadFileFromURL.class.getSimpleName(), e.toString());
+						Logger.loge(DownloadFileFromURL.class, e.toString());
 					}
 				}
 
@@ -123,7 +123,7 @@ public class DownloadFileFromURL
 				}
 				catch (Exception e)
 				{
-					Logger.loge(DownloadFileFromURL.class.getSimpleName(), e.toString());
+					Logger.loge(DownloadFileFromURL.class, "Download failed", e);
 				}
 				//super.onPostExecute(path);
 			}

--- a/app/src/main/java/nu/yona/app/utils/Logger.java
+++ b/app/src/main/java/nu/yona/app/utils/Logger.java
@@ -24,41 +24,41 @@ import nu.yona.app.BuildConfig;
 public class Logger
 {
 
-	public static void logi(String tag, String message)
+	public static void logi(Class<?> originClass, String message)
 	{
 		if (Fabric.isInitialized())
 		{
-			Crashlytics.log(Log.INFO, tag, message);
+			Crashlytics.log(Log.INFO, originClass.getName(), message);
 		}
-		Log.i(tag, message);
+		Log.i(originClass.getName(), message);
 	}
 
-	public static void loge(String tag, String message)
+	public static void loge(Class<?> originClass, String message)
 	{
 		if (Fabric.isInitialized())
 		{
-			Crashlytics.log(Log.ERROR, tag, message);
+			Crashlytics.log(Log.ERROR, originClass.getName(), message);
 		}
-		Log.e(tag, message);
+		Log.e(originClass.getName(), message);
 	}
 
-	public static void loge(String tag, String message, Exception exception)
+	public static void loge(Class<?> originClass, String message, Exception exception)
 	{
 		if (Fabric.isInitialized())
 		{
-			Crashlytics.log(Log.ERROR, tag, message);
+			Crashlytics.log(Log.ERROR, originClass.getName(), message);
 			Crashlytics.logException(exception);
 		}
-		Log.e(tag, message, exception);
+		Log.e(originClass.getName(), message, exception);
 	}
 
-	public static void logd(String tag, String message)
+	public static void logd(Class<?> originClass, String message)
 	{
 		if (Fabric.isInitialized())
 		{
-			Crashlytics.log(Log.DEBUG, tag, message);
+			Crashlytics.log(Log.DEBUG, originClass.getName(), message);
 		}
-		Log.d(tag, message);
+		Log.d(originClass.getName(), message);
 	}
 
 	public static void printStackTrace(Exception e)


### PR DESCRIPTION
Instead of using a free text, just use the name of the origin class as tag for log messages, as recommended by the Android documentation.